### PR TITLE
fix silly numpy import/fork bug

### DIFF
--- a/src/moolib.cc
+++ b/src/moolib.cc
@@ -1452,6 +1452,11 @@ PYBIND11_MODULE(_C, m) {
                  rpc::moolibModule = nullptr;
                }));
 
+  // numpy forks during import, and pybind can trigger a numpy import
+  // during serialization (just for checking if the input is a numpy array).
+  // forks generally break moolib, so do it here where it's safe
+  py::detail::npy_api::get();
+
   // pybind signatures don't play well with Sphinx
   py::options options;
   options.disable_function_signatures();


### PR DESCRIPTION
This is pretty silly, but during serialization we check if the input is a numpy array (despite #17). For this check, pybind needs to import numpy. During import, my local version of numpy calls fork. From googling, this is seen as a no-no, but it does it regardless. I've not investigated why it does the fork.
Forking during serialization breaks moolib with the usual dont-fork fatal error message (and setting the MOOLIB_ALLOW_FORK env var results in a deadlock).
There is no issue if the user already imported numpy (or pytorch, as that also pulls in numpy). However, if they didn't, even the most basic usage of moolib results in a fatal error.

This fix calls the pybind code that in turn imports numpy during Moolib module initialization, thus numpy is already imported during serialization.

