### PR TITLE
RPC update; update TensorPipe, enable infiniband, various rpc-related updates & fixes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,7 @@ jobs:
   test_sdist:
     name: Test sdist on MacOS w/ Py3.8
     runs-on: macos-latest
+    when: manual
     steps:
     - name: Setup Python 3.8 env
       uses: actions/setup-python@v2

--- a/.github/workflows/run_python_tests.yml
+++ b/.github/workflows/run_python_tests.yml
@@ -14,7 +14,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7"]
-        os: [ubuntu-latest, macos-latest]
+        #os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
       fail-fast: false
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,24 +39,33 @@ target_link_libraries(tensor PRIVATE ${TORCH_LIBRARIES})
 target_include_directories(tensor SYSTEM PRIVATE ${TORCH_INCLUDE_DIRS})
 target_compile_options(tensor PRIVATE ${TORCH_CXX_FLAGS})
 
-add_library(moorpc src/rpc.cc src/async.cc)
+add_library(moorpc OBJECT
+  src/rpc.cc
+  src/async.cc
+)
 target_link_libraries(moorpc PUBLIC tensor fmt tensorpipe)
 target_include_directories(moorpc PRIVATE src/tensorpipe src)
 
 if (USE_CUDA)
+  target_link_libraries(moorpc PUBLIC tensorpipe_cuda)
   target_compile_definitions(tensor PRIVATE -DUSE_CUDA)
   target_compile_definitions(moorpc PRIVATE -DUSE_CUDA)
 endif()
 
-pybind11_add_module(
-  _C
+pybind11_add_module(_C
+  $<TARGET_OBJECTS:moorpc>
   src/moolib.cc
   src/accumulator.cc
   src/batch_utils.cc
   src/env.cc
   src/tensorpython.cc
 )
-target_link_libraries(_C PRIVATE moorpc ${TorchPath}/lib/libtorch_python${CMAKE_SHARED_LIBRARY_SUFFIX})
+target_link_libraries(
+  _C
+  PRIVATE
+  $<TARGET_PROPERTY:moorpc,LINK_LIBRARIES>
+  ${TorchPath}/lib/libtorch_python${CMAKE_SHARED_LIBRARY_SUFFIX}
+)
 
 set_source_files_properties(src/tensorpython.cc PROPERTIES INCLUDE_DIRECTORIES "${TORCH_INCLUDE_DIRS}")
 set_source_files_properties(src/tensorpython.cc PROPERTIES COMPILE_FLAGS "${TORCH_CXX_FLAGS}")

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ def main():
 
     setuptools.setup(
         name="moolib",
-        version="0.0.9",
+        version="0.1.0",
         description=("A library for distributed ML training with PyTorch"),
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/src/accumulator.cc
+++ b/src/accumulator.cc
@@ -46,9 +46,9 @@ struct AccumulatorService {
   ResourceContainer<AccumulatorResource> resources;
 
   void close() {
-    // rpc->undefine("AccumulatorService::requestModel");
-    // rpc->undefine("AccumulatorService::modelUpdate");
-    // rpc->undefine("AccumulatorService::buffersUpdate");
+    rpc->undefine("AccumulatorService::requestModel");
+    rpc->undefine("AccumulatorService::modelUpdate");
+    rpc->undefine("AccumulatorService::buffersUpdate");
   }
 
   void setup() {

--- a/src/accumulator.cc
+++ b/src/accumulator.cc
@@ -792,9 +792,9 @@ struct AccumulatorImpl {
       throw std::runtime_error("Model buffers size mismatch in update!");
     }
 
-    //    for (size_t i = 0; i != h->modelBuffers.size(); ++i) {
-    //      h->modelBuffers[i].copy_(h->newBuffers[i], true);
-    //    }
+    for (size_t i = 0; i != h->modelBuffers.size(); ++i) {
+      h->modelBuffers[i].copy_(h->newBuffers[i], true);
+    }
   }
 
   void commitModelUpdate() {
@@ -812,12 +812,12 @@ struct AccumulatorImpl {
       throw std::runtime_error("Model parameters size mismatch in update!");
     }
 
-    //    for (size_t i = 0; i != h->modelParameters.size(); ++i) {
-    //      h->modelParameters[i].copy_(h->newParameters[i], true);
-    //    }
-    //    for (size_t i = 0; i != h->modelBuffers.size(); ++i) {
-    //      h->modelBuffers[i].copy_(h->newBuffers[i], true);
-    //    }
+    for (size_t i = 0; i != h->modelParameters.size(); ++i) {
+      h->modelParameters[i].copy_(h->newParameters[i], true);
+    }
+    for (size_t i = 0; i != h->modelBuffers.size(); ++i) {
+      h->modelBuffers[i].copy_(h->newBuffers[i], true);
+    }
 
     py::gil_scoped_acquire gil;
     userState_ = std::move(h->newUserState);

--- a/src/broker.h
+++ b/src/broker.h
@@ -80,11 +80,18 @@ struct BrokerService {
   BrokerService(rpc::Rpc& rpc) : rpc(&rpc) {
     setup();
   }
-  ~BrokerService() {}
+  ~BrokerService() {
+    close();
+  }
 
   template<typename T, typename... Args>
   Future<T> call(std::string_view peerName, std::string_view funcName, Args&&... args) {
     return callImpl<T>(*rpc, peerName, funcName, std::forward<Args>(args)...);
+  }
+
+  void close() {
+    rpc->undefine("BrokerService::groupSize");
+    rpc->undefine("BrokerService::resync");
   }
 
   void setup() {

--- a/src/group.h
+++ b/src/group.h
@@ -222,7 +222,7 @@ struct AccumulatorFindLeaderType {
 
 using ReduceVariant = std::variant<
     rpc::Tensor, std::vector<rpc::Tensor>, GilWrapper<py::object>, AccumulatorFindLeaderType, AccumulatorReductionType,
-    size_t>;
+    size_t, int>;
 
 struct BuiltinOp {
   template<typename T, typename T2>
@@ -329,7 +329,14 @@ struct GroupService {
   GroupService(rpc::Rpc& rpc) : rpc(&rpc) {
     setup();
   }
-  ~GroupService() {}
+  ~GroupService() {
+    close();
+  }
+
+  void close() {
+    rpc->undefine("GroupService::sync");
+    rpc->undefine("GroupService::update");
+  }
 
   void setup() {
 
@@ -519,6 +526,7 @@ struct AllReduceService {
   }
 
   ~AllReduceService() {
+    close();
     while (activeOps) {
       std::this_thread::yield();
     }
@@ -636,6 +644,11 @@ struct AllReduceService {
       h->flags |= 1;
       h->doCallback();
     }
+  }
+
+  void close() {
+    rpc->undefine("AllReduceService::reduce");
+    rpc->undefine("AllReduceService::share");
   }
 
   void setup() {

--- a/src/intrusive_list.h
+++ b/src/intrusive_list.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+
+namespace moolib {
+
+template<typename T>
+struct IntrusiveListLink {
+  T* prev = nullptr;
+  T* next = nullptr;
+};
+
+template<typename T, IntrusiveListLink<T> T::*link>
+struct IntrusiveList {
+private:
+  T head;
+  static T*& next(T* at) noexcept {
+    return (at->*link).next;
+  }
+  static T*& prev(T* at) noexcept {
+    return (at->*link).prev;
+  }
+
+public:
+  using value_type = T;
+  using reference = T&;
+  using const_reference = const T&;
+  using difference_type = std::ptrdiff_t;
+  using size_type = std::size_t;
+
+  struct iterator {
+  private:
+    T* ptr = nullptr;
+
+  public:
+    iterator() = default;
+    iterator(T* ptr) : ptr(ptr) {}
+
+    using difference_type = std::ptrdiff_t;
+    using value_type = T;
+    using pointer = T*;
+    using reference = T&;
+    using iterator_category = std::bidirectional_iterator_tag;
+
+    T& operator*() const noexcept {
+      return *ptr;
+    }
+    T* operator->() const noexcept {
+      return ptr;
+    }
+    iterator& operator++() noexcept {
+      ptr = next(ptr);
+      return *this;
+    }
+    iterator operator++(int) noexcept {
+      iterator r = (*this);
+      ptr = next(ptr);
+      return r;
+    }
+    iterator& operator--() noexcept {
+      ptr = prev(ptr);
+      return *this;
+    }
+    iterator operator--(int) noexcept {
+      iterator r = (*this);
+      ptr = prev(ptr);
+      return r;
+    }
+    bool operator==(iterator n) const noexcept {
+      return ptr == n.ptr;
+    }
+    bool operator!=(iterator n) const noexcept {
+      return ptr != n.ptr;
+    }
+  };
+
+  IntrusiveList() noexcept {
+    prev(&head) = &head;
+    next(&head) = &head;
+  }
+
+  iterator begin() noexcept {
+    return iterator(next(&head));
+  }
+  iterator end() noexcept {
+    return iterator(&head);
+  }
+  size_t size() = delete;
+  constexpr size_t max_size() = delete;
+  bool empty() const noexcept {
+    return next((T*)&head) == &head;
+  }
+
+  void clear() noexcept {
+    prev(&head) = &head;
+    next(&head) = &head;
+  }
+  iterator insert(iterator at, T& item) noexcept {
+    T* nextItem = &*at;
+    T* prevItem = prev(&*at);
+    prev(nextItem) = &item;
+    next(prevItem) = &item;
+    next(&item) = nextItem;
+    prev(&item) = prevItem;
+    return at;
+  }
+  static iterator erase(iterator at) noexcept {
+    T* nextItem = next(&*at);
+    T* prevItem = prev(&*at);
+    prev(nextItem) = prevItem;
+    next(prevItem) = nextItem;
+    prev(&*at) = nullptr;
+    next(&*at) = nullptr;
+    return at;
+  }
+  static void erase(T& item) noexcept {
+    erase(iterator(&item));
+  }
+  iterator push_front(T& item) noexcept {
+    return insert(begin(), item);
+  }
+  iterator push_back(T& item) noexcept {
+    return insert(end(), item);
+  }
+  void pop_front() noexcept {
+    erase(begin());
+  }
+  void pop_back() noexcept {
+    erase(prev(&head));
+  }
+  T& front() noexcept {
+    return *next(&head);
+  }
+  T& back() noexcept {
+    return *prev(&head);
+  }
+};
+
+} // namespace moolib

--- a/src/moolib.cc
+++ b/src/moolib.cc
@@ -53,8 +53,8 @@ struct PyThreadKeepAlive {
   }
   ~PyThreadKeepAlive() {
     if (tstate && --tstate->gilstate_counter == 0) {
-      PyThreadState_Clear(tstate);
       if (!_Py_IsFinalizing()) {
+        PyThreadState_Clear(tstate);
         PyThreadState_Delete(tstate);
       }
     }

--- a/src/moolib.cc
+++ b/src/moolib.cc
@@ -1402,8 +1402,13 @@ struct BatcherWrapper {
   }
 
   bool empty() {
-    std::unique_lock l(mutex);
+    std::lock_guard l(mutex);
     return queue.empty();
+  }
+
+  size_t size() {
+    std::lock_guard l(mutex);
+    return queue.size();
   }
 
   py::object get() {
@@ -1431,6 +1436,14 @@ struct BatcherWrapper {
     batcher.cat(std::move(data), [this](py::object value) { enqueue(value); });
   }
 };
+
+void callRpcDeferredReturn(rpc::RpcDeferredReturn<GilWrapper<py::object>>& o, const py::object& v) {
+  o(v);
+}
+
+void callFunction(rpc::Function<void(GilWrapper<py::object>)>& o, const py::object& v) {
+  o(v);
+}
 
 void set_log_level(py::object level) {
   if (py::isinstance<py::str>(level)) {
@@ -1728,6 +1741,7 @@ PYBIND11_MODULE(_C, m) {
       )d"))
       .def("model_version", &Accumulator::modelVersion, py::doc(R"d(
         Return the current model version.
+
         This number is automatically incremented when ``zero_gradients`` is called.
         The peer with the highest model version will be selected as the leader.
 
@@ -1737,15 +1751,21 @@ PYBIND11_MODULE(_C, m) {
       .def("set_model_version", &Accumulator::setModelVersion, py::arg("n"), py::doc(R"d(
          Set the current model version.
 
-         The default value is:
+         This function should be called e.g. when a model is loaded from a checkpoint,
+         to inform Moolib of the real model version. In this case, it's best to do it before
+         calling ``Accumulator.update`` for the first time.
+
+         Calling this function will *not* trigger any synchronization, in particular the leader
+         will not change immediately, but may change later based on the set value if synchronization
+         occurs (e.g. when a peer joins or leaves).
 
          Args:
-             n (int): the virtual batch size.
+             n (int): the new model version.
        )d"))
       .def("set_virtual_batch_size", &Accumulator::setVirtualBatchSize, py::arg("n"), py::doc(R"d(
         Set the virtual batch size of the reduction operation.
 
-        The default value is:
+        The default value is: 1
 
         Args:
             n (int): the virtual batch size.
@@ -1753,7 +1773,12 @@ PYBIND11_MODULE(_C, m) {
       .def("set_parallel_gradients", &Accumulator::setParallelGradients, py::arg("n"), py::doc(R"d(
         Set the number of parallel gradient reduction operations.
 
-        The default value is:
+        If this value is set to >1, multiple sets of gradients may be accumulated simultaneously.
+        In this case, gradients may have been calculated using a previous model version (up to `n` versions ago).
+        This can allow using smaller virtual batch sizes, when many peers generate data quickly.
+        Gradients will always be applied (through ``has_gradients``) in the same order on all peers.
+
+        The default value is: 1
 
         Args:
             n (int): the number of parallel gradient operations.
@@ -1779,7 +1804,7 @@ PYBIND11_MODULE(_C, m) {
             (dict): statistics about the gradient syncing.
       )d"));
   py::class_<BatcherWrapper>(m, "Batcher", R"d(
-    A auxiliary class to asynchronously batch tensors into an chosen batch size on a certain device.
+    An auxiliary class to asynchronously batch tensors into an chosen batch size on a certain device.
 
     This class will often be used in an RL setting, see ``examples/impala/impala.py``, with batching
     happening in a background thread. This class is ``awaitable`` with asyncio.
@@ -1830,6 +1855,12 @@ PYBIND11_MODULE(_C, m) {
         Returns:
             bool:
       )d"))
+      .def("size", &BatcherWrapper::size, py::doc(R"d(
+        Returns the size of the batched queue of data.
+
+        Returns:
+            int:
+      )d"))
       .def("get", &BatcherWrapper::get, py::doc(R"d(
         Return a batched tensor.
 
@@ -1842,7 +1873,10 @@ PYBIND11_MODULE(_C, m) {
   py::class_<rpc::RpcDeferredReturn<GilWrapper<py::object>>>(m, "RpcDeferredReturn", R"d(
     A deferred return from call to a ``define_deferred`` function.
   )d")
-      .def("__call__", &rpc::RpcDeferredReturn<GilWrapper<py::object>>::operator()<const py::object&>);
+      .def("__call__", &callRpcDeferredReturn);
+  py::class_<rpc::Function<void(GilWrapper<py::object>)>>(m, "Function", R"d(
+  )d")
+      .def("__call__", &callFunction);
   py::class_<QueueWrapper, std::shared_ptr<QueueWrapper>>(m, "Queue", R"d(
     A tensorpipe Queue class.
   )d")
@@ -1951,6 +1985,14 @@ PYBIND11_MODULE(_C, m) {
             function (Callable[[], None]): a Python function, for peers to call.
             kwargs: specifications for how to treat Tensor arguments to the function.
       )d"))
+      .def("undefine", &RpcWrapper::undefine, py::arg("name"), py::doc(R"(
+        Undefine a previously defined function.
+
+        This function will block until all current calls to the function have completed.
+
+        Args:
+            name (str): a name corresponding to a previous call to ``define``.
+      )"))
       .def("define_deferred", &RpcWrapper::defineDeferred, py::doc(R"d(
         Define a deferred function to be available for peers to call.
 
@@ -2074,6 +2116,8 @@ PYBIND11_MODULE(_C, m) {
       .def("cancel", &FutureWrapper::cancel, py::doc(R"d(Cancel the future calculation.)d"))
       .def("done", &FutureWrapper::done, py::doc(R"d(Check if the future has finished.)d"))
       .def("exception", &FutureWrapper::exception, py::doc("Returns the exception that occurred, if any."))
+      .def("wait", (void (FutureWrapper::*)()) & FutureWrapper::wait)
+      .def("wait", (void (FutureWrapper::*)(float)) & FutureWrapper::wait)
       .def("__await__", &FutureWrapper::await)
       .def("__iter__", &FutureWrapper::await);
   py::class_<Broker>(m, "Broker", R"d(
@@ -2177,6 +2221,8 @@ PYBIND11_MODULE(_C, m) {
       .def("cancel", &AllReduceWrapper::cancel, py::doc(R"d(Cancel the future calculation.)d"))
       .def("done", &AllReduceWrapper::done, py::doc(R"d(Check if the future has finished.)d"))
       .def("exception", &AllReduceWrapper::exception, py::doc("Returns the exception that occurred, if any."))
+      .def("wait", (void (AllReduceWrapper::*)()) & AllReduceWrapper::wait)
+      .def("wait", (void (AllReduceWrapper::*)(float)) & AllReduceWrapper::wait)
       .def("__await__", &AllReduceWrapper::await)
       .def("__iter__", &AllReduceWrapper::await);
 }

--- a/src/moolib.cc
+++ b/src/moolib.cc
@@ -12,7 +12,6 @@
 #include "group.h"
 #include "logging.h"
 #include "pythonserialization.h"
-#include "rpc.h"
 #include "shm.h"
 #include "synchronization.h"
 #include "util.h"
@@ -21,6 +20,8 @@
 #include "pybind11/numpy.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
+
+#include "rpc.h"
 
 #include <list>
 #include <vector>
@@ -308,65 +309,68 @@ struct FutureWrapper {
     py::object loop = moduleState->get_running_loop();
     py::object future = loop.attr("create_future")();
 
-    callback = rpc::Function<void()>([me = shared(), loop = GilWrapper<py::object>(std::move(loop)),
-                                      future = GilWrapper<py::object>(future)]() mutable noexcept {
-                 int f = me->flags.load(std::memory_order_relaxed);
-                 py::gil_scoped_acquire gil;
-                 if (_Py_IsFinalizing()) {
-                   return;
-                 }
-                 try {
-                   keepThreadAlive();
-                   if (f & 1) {
-                     loop->attr("call_soon_threadsafe")(
-                         py::cpp_function([me = std::move(me), future = std::move(future)]() mutable {
-                           try {
-                             if (!me->value) {
-                               future->attr("set_exception")(py::reinterpret_borrow<py::object>(PyExc_RuntimeError)(
-                                   "Future value not available. Maybe it has already been retrieved"));
-                             } else {
-                               future->attr("set_result")(me->value.release());
-                             }
-                           } catch (const py::error_already_set& e) {
-                             // InvalidStateError probably means that the future was cancelled
-                             if (!e.matches(py::module::import("asyncio").attr("InvalidStateError"))) {
-                               throw;
-                             }
-                           }
-                         }));
-                   } else if (f & 2) {
-                     try {
-                       loop->attr("call_soon_threadsafe")(py::cpp_function([me, future = std::move(future)]() mutable {
-                         try {
-                           std::lock_guard l(me->errorMutex);
-                           future->attr("set_exception")(
-                               py::reinterpret_borrow<py::object>(PyExc_RuntimeError)(me->error->what()));
-                         } catch (const py::error_already_set& e) {
-                           if (!e.matches(py::module::import("asyncio").attr("InvalidStateError"))) {
-                             throw;
-                           }
-                         }
-                       }));
-                     } catch (const py::error_already_set& e) {
-                       std::string s;
-                       {
-                         std::lock_guard l(me->errorMutex);
-                         s = me->error->what();
-                       }
-                       fatal("Python exception during callback: %s\nOriginal exception: %s", e.what(), s);
-                     }
-                   } else if (f & 4) {
-                     loop->attr("call_soon_threadsafe")(
-                         py::cpp_function([future = std::move(future)]() mutable { future->attr("cancel")(); }));
-                   } else {
-                     fatal("Future callback called in invalid state");
-                   }
-                 } catch (const py::error_already_set& e) {
-                   fatal("Python exception during callback: %s", e.what());
-                 }
-                 future.reset();
-                 loop.reset();
-               }).release();
+    py::object call_soon_threadsafe = loop.attr("call_soon_threadsafe");
+
+    callback =
+        rpc::Function<void()>([me = shared(),
+                               call_soon_threadsafe = GilWrapper<py::object>(std::move(call_soon_threadsafe)),
+                               future = GilWrapper<py::object>(future)]() mutable noexcept {
+          int f = me->flags.load(std::memory_order_relaxed);
+          py::gil_scoped_acquire gil;
+          if (_Py_IsFinalizing()) {
+            return;
+          }
+          try {
+            keepThreadAlive();
+            if (f & 1) {
+              (*call_soon_threadsafe)(py::cpp_function([me = std::move(me), future = std::move(future)]() mutable {
+                try {
+                  if (!me->value) {
+                    future->attr("set_exception")(py::reinterpret_borrow<py::object>(PyExc_RuntimeError)(
+                        "Future value not available. Maybe it has already been retrieved"));
+                  } else {
+                    future->attr("set_result")(me->value.release());
+                  }
+                } catch (const py::error_already_set& e) {
+                  // InvalidStateError probably means that the future was cancelled
+                  if (!e.matches(py::module::import("asyncio").attr("InvalidStateError"))) {
+                    throw;
+                  }
+                }
+              }));
+            } else if (f & 2) {
+              try {
+                (*call_soon_threadsafe)(py::cpp_function([me, future = std::move(future)]() mutable {
+                  try {
+                    std::lock_guard l(me->errorMutex);
+                    future->attr("set_exception")(
+                        py::reinterpret_borrow<py::object>(PyExc_RuntimeError)(me->error->what()));
+                  } catch (const py::error_already_set& e) {
+                    if (!e.matches(py::module::import("asyncio").attr("InvalidStateError"))) {
+                      throw;
+                    }
+                  }
+                }));
+              } catch (const py::error_already_set& e) {
+                std::string s;
+                {
+                  std::lock_guard l(me->errorMutex);
+                  s = me->error->what();
+                }
+                fatal("Python exception during callback: %s\nOriginal exception: %s", e.what(), s);
+              }
+            } else if (f & 4) {
+              (*call_soon_threadsafe)(
+                  py::cpp_function([future = std::move(future)]() mutable { future->attr("cancel")(); }));
+            } else {
+              fatal("Future callback called in invalid state");
+            }
+          } catch (const py::error_already_set& e) {
+            fatal("Python exception during callback: %s", e.what());
+          }
+          future.reset();
+          call_soon_threadsafe.reset();
+        }).release();
     if (flags.load() != 0) {
       doCallback();
     }
@@ -406,7 +410,7 @@ struct Promise {
 };
 
 struct QueueEntry {
-  rpc::RpcDeferredReturn<GilWrapper<py::object>> ret;
+  rpc::Function<void(GilWrapper<py::object>)> ret;
   std::optional<GilWrapper<py::args>> args;
   std::optional<GilWrapper<py::kwargs>> kwargs;
   std::chrono::steady_clock::time_point timestamp;
@@ -423,7 +427,7 @@ struct QueueWrapper {
   std::deque<Promise<FutureWrapper>> waiters;
 
   void setResult(
-      Promise<FutureWrapper>& promise, rpc::RpcDeferredReturn<GilWrapper<py::object>>&& ret,
+      Promise<FutureWrapper>& promise, rpc::Function<void(GilWrapper<py::object>)>&& ret,
       std::optional<GilWrapper<py::args>>&& args, std::optional<GilWrapper<py::kwargs>>&& kwargs) {
     py::object o;
     {
@@ -441,11 +445,8 @@ struct QueueWrapper {
     promise.setResult(std::move(o));
   }
 
-  void setBatchResult(
-      std::vector<std::tuple<
-          rpc::RpcDeferredReturn<GilWrapper<py::object>>, std::optional<GilWrapper<py::args>>,
-          std::optional<GilWrapper<py::kwargs>>>>&& batch,
-      Promise<FutureWrapper>& result) const {
+  template<typename Batch>
+  void setBatchResult(Batch&& batch, Promise<FutureWrapper>& result) const {
     py::object o;
     {
       py::gil_scoped_acquire gil;
@@ -456,7 +457,7 @@ struct QueueWrapper {
       const int64_t curBatchSize = batch.size();
       // Somehow std::vector<py::handle> doesn't work here.
       py::tuple src(curBatchSize);
-      std::vector<rpc::RpcDeferredReturn<GilWrapper<py::object>>> retCallbacks;
+      std::vector<rpc::Function<void(GilWrapper<py::object>)>> retCallbacks;
       retCallbacks.reserve(curBatchSize);
       for (int64_t i = 0; i < curBatchSize; ++i) {
         auto& [ret, args, kwargs] = batch[i];
@@ -466,9 +467,9 @@ struct QueueWrapper {
             kwargs ? (py::object)*std::move(*kwargs) : (py::object)py::none());
       }
 
-      rpc::RpcDeferredReturn<GilWrapper<py::object>> retCallback;
-      retCallback.f = [curBatchSize, dim = batchDim,
-                       retCallbacks = std::move(retCallbacks)](GilWrapper<py::object> input) mutable {
+      rpc::Function<void(GilWrapper<py::object>)> retCallback;
+      retCallback = [curBatchSize, dim = batchDim,
+                     retCallbacks = std::move(retCallbacks)](GilWrapper<py::object> input) mutable {
         if (input->is_none()) {
           for (auto& retCallback : retCallbacks) {
             retCallback(py::none());
@@ -482,14 +483,13 @@ struct QueueWrapper {
         }
       };
       py::tuple args = py::reinterpret_borrow<py::tuple>(utils::stackFields(src, batchDim));
-      o = py::make_tuple(
-          py::cast(std::move(retCallback), py::return_value_policy::move), std::move(args[0]), std::move(args[1]));
+      o = py::make_tuple(py::cast(std::move(retCallback), py::return_value_policy::move), args[0], args[1]);
     }
     result.setResult(std::move(o));
   }
 
   void enqueue(
-      rpc::RpcDeferredReturn<GilWrapper<py::object>> ret, std::optional<GilWrapper<py::args>> args,
+      rpc::Function<void(GilWrapper<py::object>)> ret, std::optional<GilWrapper<py::args>> args,
       std::optional<GilWrapper<py::kwargs>> kwargs) {
     {
       std::unique_lock l(mutex);
@@ -503,10 +503,13 @@ struct QueueWrapper {
         waiters.pop_front();
         l.unlock();
         if (batchSize > 0) {
-          std::vector<std::tuple<
-              rpc::RpcDeferredReturn<GilWrapper<py::object>>, std::optional<GilWrapper<py::args>>,
-              std::optional<GilWrapper<py::kwargs>>>>
-              batch = {std::make_tuple(std::move(ret), std::move(args), std::move(kwargs))};
+          std::array<
+              std::tuple<
+                  rpc::Function<void(GilWrapper<py::object>)>, std::optional<GilWrapper<py::args>>,
+                  std::optional<GilWrapper<py::kwargs>>>,
+              1>
+              batch;
+          batch[0] = std::make_tuple(std::move(ret), std::move(args), std::move(kwargs));
           setBatchResult(std::move(batch), promise);
         } else {
           setResult(promise, std::move(ret), std::move(args), std::move(kwargs));
@@ -533,7 +536,7 @@ struct QueueWrapper {
           const int64_t queSize = queue.size();
           const int64_t curBatchSize = std::min(batchSize, queSize);
           std::vector<std::tuple<
-              rpc::RpcDeferredReturn<GilWrapper<py::object>>, std::optional<GilWrapper<py::args>>,
+              rpc::Function<void(GilWrapper<py::object>)>, std::optional<GilWrapper<py::args>>,
               std::optional<GilWrapper<py::kwargs>>>>
               batch;
           batch.reserve(curBatchSize);
@@ -650,13 +653,13 @@ struct Batcher {
         }
         n -= offset;
         if (n <= batchSize && offset == 0) {
-          tensor.narrow(batchDimension, 0, n).copy_(*t);
+          tensor.narrow(batchDimension, 0, n).copy_(*t, true);
         } else {
           n = std::min(n, batchSize);
-          tensor.narrow(batchDimension, 0, n).copy_(t->narrow(batchDimension, offset, n));
+          tensor.narrow(batchDimension, 0, n).copy_(t->narrow(batchDimension, offset, n), true);
         }
       } else {
-        tensor.select(batchDimension, 0).copy_(*t);
+        tensor.select(batchDimension, 0).copy_(*t, true);
       }
       ++nTensors;
       return rpc::toPython(tensor);
@@ -725,13 +728,13 @@ struct Batcher {
         int64_t left = batchSize - outputOffset;
         n -= inputOffset;
         if (n <= left && inputOffset == 0) {
-          destT->narrow(batchDimension, outputOffset, n).copy_(*sourceT);
+          destT->narrow(batchDimension, outputOffset, n).copy_(*sourceT, true);
         } else {
           n = std::min(n, left);
-          destT->narrow(batchDimension, outputOffset, n).copy_(sourceT->narrow(batchDimension, inputOffset, n));
+          destT->narrow(batchDimension, outputOffset, n).copy_(sourceT->narrow(batchDimension, inputOffset, n), true);
         }
       } else {
-        destT->select(batchDimension, nextStackIndex).copy_(*sourceT);
+        destT->select(batchDimension, nextStackIndex).copy_(*sourceT, true);
       }
       ++currentTensor;
     } else if (py::isinstance<py::tuple>(dest)) {
@@ -827,49 +830,47 @@ struct Batcher {
     return {};
   }
 
-  void prepareForUnbatch(const py::handle& v, std::vector<std::pair<py::object, rpc::Tensor>>& tensors) {
+  template<typename F>
+  py::object prepareForUnbatchCopy(const py::handle& v, F&& f) {
     if (py::isinstance<py::dict>(v)) {
       const py::dict& dict = py::reinterpret_borrow<py::dict>(v);
+      py::dict newdict;
       for (auto& [key, value] : dict) {
-        prepareForUnbatch(value, tensors);
+        newdict[key] = prepareForUnbatchCopy(value, f);
       }
+      return std::move(newdict);
     } else if (py::isinstance<py::list>(v)) {
       const py::list& list = py::reinterpret_borrow<py::list>(v);
       size_t n = list.size();
+      py::list newlist(n);
       for (size_t i = 0; i != n; ++i) {
-        prepareForUnbatch(list[i], tensors);
+        newlist[i] = prepareForUnbatchCopy(list[i], f);
       }
+      return std::move(newlist);
     } else if (auto t = rpc::tryFromPython(v)) {
-      tensors.emplace_back(py::reinterpret_borrow<py::object>(v), t->to(rpc::kCPU));
+      return f(v, *t);
     } else if (py::isinstance<py::tuple>(v)) {
       const py::tuple& tuple = py::reinterpret_borrow<py::tuple>(v);
       size_t n = tuple.size();
+      py::tuple newtuple(n);
       for (size_t i = 0; i != n; ++i) {
-        prepareForUnbatch(tuple[i], tensors);
+        newtuple[i] = prepareForUnbatchCopy(tuple[i], f);
       }
+      return std::move(newtuple);
+    } else {
+      return py::reinterpret_borrow<py::object>(v);
     }
   }
-
-  std::vector<std::pair<py::object, rpc::Tensor>> unbatchTensors;
 
   template<typename T>
   void unbatch(py::object v, T&& callbacks) {
     std::lock_guard l(*unbatchMutex);
-    auto& tensors = unbatchTensors;
-    prepareForUnbatch(v, tensors);
+    v = prepareForUnbatchCopy(v, [&](auto&, rpc::Tensor& t) { return rpc::toPython(t.cpu()); });
     size_t n = callbacks.size();
     for (size_t i = 0; i != n; ++i) {
-      for (auto& [o, t] : tensors) {
-        if (t.size(0) != (int64_t)n) {
-          throw std::runtime_error(
-              fmt::sprintf("unexpected batch size in output tensor: got %d, expected %d", t.size(0), n));
-        }
-        setPythonTensor(o, t[i]);
-      }
-      callbacks[i](v);
+      auto iv = prepareForUnbatchCopy(v, [&](auto&, rpc::Tensor& t) { return rpc::toPython(t[i]); });
+      callbacks[i](iv);
     }
-
-    unbatchTensors.clear();
   }
 };
 
@@ -986,9 +987,13 @@ struct RpcWrapper {
     rpc->connect(addr);
   }
 
+  void undefine(std::string_view name) {
+    rpc->undefine(name);
+  }
+
   void define(std::string_view name, py::function callback, py::kwargs kwargs) {
     if (kwargs.contains("batch_size") && kwargs["batch_size"].ptr() != Py_None) {
-      using MyBatcher = Batcher<rpc::RpcDeferredReturn<GilWrapper<py::object>>>;
+      using MyBatcher = Batcher<rpc::Function<void(GilWrapper<py::object>)>>;
       MyBatcher batcher;
       int batchSize = py::cast<int>(kwargs["batch_size"]);
       if (kwargs.contains("device")) {
@@ -1037,7 +1042,7 @@ struct RpcWrapper {
 
   void defineDeferred(std::string_view name, py::function callback, py::kwargs kwargs) {
     if (kwargs.contains("batch_size") && kwargs["batch_size"].ptr() != Py_None) {
-      using MyBatcher = Batcher<rpc::RpcDeferredReturn<GilWrapper<py::object>>>;
+      using MyBatcher = Batcher<rpc::Function<void(GilWrapper<py::object>)>>;
       std::shared_ptr<MyBatcher> batcher;
       int batchSize = py::cast<int>(kwargs["batch_size"]);
       if (kwargs.contains("device")) {
@@ -1106,7 +1111,7 @@ struct RpcWrapper {
               q->enqueue(std::move(returnCallback), std::move(args), std::move(kwargs));
             });
       } else {
-        using MyBatcher = Batcher<rpc::RpcDeferredReturn<GilWrapper<py::object>>>;
+        using MyBatcher = Batcher<rpc::Function<void(GilWrapper<py::object>)>>;
         std::shared_ptr<MyBatcher> batcher;
         if (kwargs.contains("device")) {
           std::string device = py::cast<std::string>(kwargs["device"]);
@@ -1126,8 +1131,8 @@ struct RpcWrapper {
               auto retval = batcher->stack(getBatchValue(args, kwargs), std::move(returnCallback));
               if (retval) {
                 py::object o = std::move(retval->first);
-                rpc::RpcDeferredReturn<GilWrapper<py::object>> returnCallback2;
-                returnCallback2.f = [batcher, retval = std::move(retval)](GilWrapper<py::object> r) mutable {
+                rpc::Function<void(GilWrapper<py::object>)> returnCallback2;
+                returnCallback2 = [batcher, retval = std::move(retval)](GilWrapper<py::object> r) mutable {
                   batcher->unbatch(std::move(*r), retval->second);
                 };
                 applyArgs(args, kwargs, ApplyToQueue(*q), o, std::move(returnCallback2));
@@ -1330,6 +1335,24 @@ struct GroupWrapper : Group {
     }
     throw std::runtime_error(
         "all_reduce can only use the default operator on Tensor data. Please specify an operator function");
+  }
+
+  std::shared_ptr<AllReduceWrapper> synchronize(std::string name) {
+    GilWrapper<py::object> result = py::none();
+    py::gil_scoped_release gil;
+    Promise<AllReduceWrapper> promise;
+    auto future = promise.getFuture();
+    auto h = Group::allReduce(
+        "!sync-" + name, 0, [](auto&, auto&) {},
+        [promise = std::move(promise), result = std::move(result)](int* r, rpc::Error* error) mutable noexcept {
+          if (r) {
+            promise.setResult(std::move(result));
+          } else {
+            promise.setException(std::move(*error));
+          }
+        });
+    future->h = std::move(h);
+    return future;
   }
 };
 

--- a/src/pyutil.h
+++ b/src/pyutil.h
@@ -17,16 +17,22 @@ namespace py = pybind11;
 
 template<typename T>
 struct glock {
-  std::unique_lock<T> lock;
-  glock(T& mutex) : lock(mutex, std::try_to_lock) {
-    if (!lock.owns_lock()) {
+  std::unique_lock<T> ulock;
+  glock(T& mutex) : ulock(mutex, std::try_to_lock) {
+    if (!ulock.owns_lock()) {
       if (PyGILState_Check()) {
         py::gil_scoped_release gil;
-        lock.lock();
+        ulock.lock();
       } else {
-        lock.lock();
+        ulock.lock();
       }
     }
+  }
+  void lock() {
+    ulock.lock();
+  }
+  void unlock() {
+    ulock.unlock();
   }
 };
 

--- a/src/rpc.cc
+++ b/src/rpc.cc
@@ -32,7 +32,7 @@ async::SchedulerFifo scheduler;
 
 std::mutex logMutex;
 
-constexpr bool loggingEnabled = false;
+constexpr bool logLevel = 0;
 
 template<typename... Args>
 void logimpl(const char* fmt, Args&&... args) {
@@ -55,10 +55,15 @@ void logimpl(const char* fmt, Args&&... args) {
 }
 
 template<typename... Args>
-void log(const char* fmt, Args&&... args) {
-  if (loggingEnabled) {
+void log(int level, const char* fmt, Args&&... args) {
+  if (level <= logLevel) {
     logimpl(fmt, std::forward<Args>(args)...);
   }
+}
+
+template<typename... Args>
+void log(const char* fmt, Args&&... args) {
+  log(10, fmt, std::forward<Args>(args)...);
 }
 
 template<typename... Args>
@@ -2633,11 +2638,16 @@ struct Rpc::Impl {
   }
 
   template<typename... Args>
-  void log(const char* fmt, Args&&... args) {
-    if (loggingEnabled) {
+  void log(int level, const char* fmt, Args&&... args) {
+    if (level <= logLevel) {
       auto s = fmt::sprintf(fmt, std::forward<Args>(args)...);
-      rpc::log("%s: %s", myName, s);
+      rpc::log(level, "%s: %s", myName, s);
     }
+  }
+
+  template<typename... Args>
+  void log(const char* fmt, Args&&... args) {
+    log(10, fmt, std::forward<Args>(args)...);
   }
 
   void cleanup(Rpc::Impl::Incoming& o, Deferrer& defer) {

--- a/test/test.py
+++ b/test/test.py
@@ -7,6 +7,8 @@ import moolib
 import time
 import torch
 
+moolib.set_max_threads(1)
+
 
 def main():
 
@@ -77,13 +79,12 @@ def main():
             print(e)
 
         host = moolib.Rpc()
+        host.define("hello", hello)
         host.set_name("host")
         host.listen(localAddr)
-        host.set_timeout(30)
 
-        # host does not connect to client, so this would normally not work
-        # but since client lost connection to host, it should reconnect automatically
-        print(host.sync("client", "client hello", "I", "am", "back!"))
+        client.set_timeout(30)
+        print(client.sync("host", "hello", "is host alive?"))
 
     weights = torch.randn(4096, 4096)
 

--- a/test/test.py
+++ b/test/test.py
@@ -7,6 +7,7 @@ import moolib
 import time
 import torch
 
+
 def main():
 
     localAddr = "127.0.0.1:4411"

--- a/test/test.py
+++ b/test/test.py
@@ -7,9 +7,6 @@ import moolib
 import time
 import torch
 
-moolib.set_max_threads(1)
-
-
 def main():
 
     localAddr = "127.0.0.1:4411"

--- a/test/test_asyncio.py
+++ b/test/test_asyncio.py
@@ -78,13 +78,12 @@ async def main():
             print(e)
 
         host = moolib.Rpc()
+        host.define("hello", hello)
         host.set_name("host")
         host.listen(localAddr)
-        host.set_timeout(30)
 
-        # host does not connect to client, so this would normally not work
-        # but since client lost connection to host, it should reconnect automatically
-        print(host.sync("client", "client hello", "I", "am", "back!"))
+        client.set_timeout(30)
+        print(client.sync("host", "hello", "is host alive?"))
 
     weights = torch.randn(4096, 4096)
 

--- a/test/unit/test_simple.py
+++ b/test/unit/test_simple.py
@@ -90,10 +90,11 @@ class TestMoolib:
 
         called = False
 
-        def client_hello(*args):
+        def client_hello(a, b, c):
             nonlocal called
             called = True
-            print("client got hello:", (*args,))
+            assert (a, b, c) == (1, 2, 3)
+            return (c, b, a)
 
         client.define("client hello", client_hello)
 
@@ -129,4 +130,5 @@ class TestMoolib:
 
         client.set_timeout(30)
         assert client.sync("host", "hello", "is host alive?") == 42
+        assert host.sync("client", "client hello", 1, 2, 3) == (3, 2, 1)
         assert called

--- a/test/unit/test_simple.py
+++ b/test/unit/test_simple.py
@@ -98,7 +98,7 @@ class TestMoolib:
         client.define("client hello", client_hello)
 
         def hello(message):
-            pass
+            return 42
 
         host.define("hello", hello)
         host.set_name("host")
@@ -123,12 +123,10 @@ class TestMoolib:
             client.sync("host", "hello", "is host dead?")
 
         host = moolib.Rpc()
+        host.define("hello", hello)
         host.set_name("host")
         host.listen(ADDRESS)
-        host.set_timeout(30)
 
-        # host does not connect to client, so this would normally not work
-        # but since client lost connection to host, it should reconnect automatically
-        # TODO: This call adds ~8 sec to the test.
-        host.sync("client", "client hello", "I", "am", "back!")
+        client.set_timeout(30)
+        assert client.sync("host", "hello", "is host alive?") == 42
         assert called


### PR DESCRIPTION
This brings tensorpipe up to date with the latest version.
InfiniBand is now enabled by default, and all of the code for handling CUDA tensors is present in the RPC, but CUDA is still disabled by default, as CUDA tensors are not yet supported in all-reduce, and a bit more testing should be done.

It's a fair bit of code, but among some fixes/changes:
 - Batcher broke in pytorch 1.10, so that's fixed.
 - Properly clean up defined functions and their resources on shutdown.
 - Better? thread scheduling in some places, some deadlocks also fixed/avoided in this way.
 - Some performance improvements, although there are also some regressions. The best performance in the general case seem to still be achieved by doing moolib.set_max_threads(1), and this warrants further investigation.
