### PR TITLE
New native sockets transport, tcp + ipc.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,8 +42,10 @@ target_compile_options(tensor PRIVATE ${TORCH_CXX_FLAGS})
 add_library(moorpc OBJECT
   src/rpc.cc
   src/async.cc
+  src/transports/socket.cc
+  src/transports/ipc.cc
 )
-target_link_libraries(moorpc PUBLIC tensor fmt tensorpipe)
+target_link_libraries(moorpc PUBLIC tensor fmt tensorpipe anl)
 target_include_directories(moorpc PRIVATE src/tensorpipe src)
 
 if (USE_CUDA)
@@ -66,6 +68,7 @@ target_link_libraries(
   $<TARGET_PROPERTY:moorpc,LINK_LIBRARIES>
   ${TorchPath}/lib/libtorch_python${CMAKE_SHARED_LIBRARY_SUFFIX}
 )
+target_include_directories(_C PRIVATE src)
 
 set_source_files_properties(src/tensorpython.cc PROPERTIES INCLUDE_DIRECTORIES "${TORCH_INCLUDE_DIRS}")
 set_source_files_properties(src/tensorpython.cc PROPERTIES COMPILE_FLAGS "${TORCH_CXX_FLAGS}")

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ def main():
 
     setuptools.setup(
         name="moolib",
-        version="0.1.0",
+        version="0.2.0",
         description=("A library for distributed ML training with PyTorch"),
         long_description=long_description,
         long_description_content_type="text/markdown",

--- a/src/moolib.cc
+++ b/src/moolib.cc
@@ -52,8 +52,8 @@ struct PyThreadKeepAlive {
     tstate = std::exchange(n.tstate, nullptr);
   }
   ~PyThreadKeepAlive() {
-    if (tstate && --tstate->gilstate_counter == 0) {
-      if (!_Py_IsFinalizing()) {
+    if (!_Py_IsFinalizing()) {
+      if (tstate && --tstate->gilstate_counter == 0) {
         PyThreadState_Clear(tstate);
         PyThreadState_Delete(tstate);
       }

--- a/src/rpc.cc
+++ b/src/rpc.cc
@@ -1708,13 +1708,6 @@ struct Rpc::Impl {
           for (auto& v2 : v.second.connections_) {
             std::lock_guard l4(v2.mutex);
             for (auto& v3 : v2.conns) {
-              // BufferHandle buffer;
-              // serializeToBuffer(buffer, (uint32_t)0, (uint32_t)reqClose);
-              // TensorContext nullTensorContext;
-              // switchOnAPI((ConnectionType)v3->apiIndex(), [&](auto api) {
-              //   ((RpcConnectionImpl<decltype(api)>&)*v3).send(std::move(buffer), nullTensorContext, defer);
-              // });
-
               defer([ptr = &*v3] { ptr->close(); });
               garbageConnections_.push_back(std::move(v3));
             }

--- a/src/rpc.h
+++ b/src/rpc.h
@@ -39,57 +39,6 @@ extern async::SchedulerFifo scheduler;
 template<typename R>
 using CallbackFunction = Function<void(R*, Error* error)>;
 
-#if 0
-template<typename T>
-struct Me {
-  T* me = nullptr;
-  const char* filename;
-  int line;
-  Me() = default;
-  Me(std::nullptr_t) noexcept {}
-  explicit Me(T* me, const char* filename, int line) noexcept : me(me), filename(filename), line(line) {
-    if (me) {
-      int n = me->activeOps.fetch_add(1, std::memory_order_relaxed) + 1;
-      printf("addref %d %p at %s:%d\n", n, (void*)me, filename, line);
-    }
-  }
-  Me(const Me&) = delete;
-  Me(Me&& n) noexcept {
-    me = std::exchange(n.me, nullptr);
-    filename = n.filename;
-    line = n.line;
-  }
-  Me& operator=(const Me&) = delete;
-  Me& operator=(Me&& n) noexcept {
-    std::swap(me, n.me);
-    std::swap(filename, n.filename);
-    std::swap(line, n.line);
-    return *this;
-  }
-  ~Me() {
-    if (me) {
-      int n = me->activeOps.fetch_sub(1) - 1;
-      printf("decref %d %p at %s:%d\n", n, (void*)me, filename, line);
-    }
-  }
-  T* operator->() const noexcept {
-    return me;
-  }
-  T& operator*() const noexcept {
-    return *me;
-  }
-  explicit operator bool() const noexcept {
-    return me;
-  }
-};
-
-template<typename T>
-auto makeMeImpl(T* v, const char* filename, int line) {
-  return Me<T>(v, filename, line);
-}
-#define makeMe(v) makeMeImpl(v, __FILE__, __LINE__)
-
-#else
 template<typename T>
 struct Me {
   T* me = nullptr;
@@ -129,7 +78,6 @@ template<typename T>
 auto makeMe(T* v) {
   return Me<T>(v);
 }
-#endif
 
 struct TensorContext {
   std::optional<rpc::CUDAStream> stream;

--- a/src/serialization.h
+++ b/src/serialization.h
@@ -445,4 +445,14 @@ std::string_view deserializeBufferPart(Buffer* buffer, T&... result) {
   return des.buf;
 }
 
+template<typename T>
+struct SerializeFunction {
+  const T& f;
+  SerializeFunction(const T& f) : f(f) {}
+  template<typename X>
+  void serialize(X& x) {
+    f(x);
+  }
+};
+
 } // namespace rpc

--- a/src/transports/ipc.cc
+++ b/src/transports/ipc.cc
@@ -1,0 +1,245 @@
+
+#include "ipc.h"
+
+#include <limits.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+namespace rpc {
+
+extern thread_local bool callbackScheduledFromBackend;
+
+namespace ipc {
+
+static size_t computeStorageNbytes(IntArrayRef sizes, IntArrayRef strides, size_t itemsize_bytes) {
+  // size of the underlying storage is 1 bigger than the offset
+  // of the last element according to stride
+  size_t size = 1;
+  for (size_t i = 0; i < sizes.size(); i++) {
+    if (sizes[i] == 0) {
+      return 0;
+    }
+    size += strides[i] * (sizes[i] - 1);
+  }
+  return size * itemsize_bytes;
+}
+
+void Listener::accept(Function<void(Error*, std::shared_ptr<Connection>)> callback) {
+  socket.accept([this, callback = std::move(callback)](Error* error, Socket socket) {
+    if (error) {
+      callback(error, nullptr);
+    } else {
+      auto connection = std::make_shared<Connection>(std::move(socket));
+      callback(nullptr, std::move(connection));
+    }
+  });
+}
+
+std::string Listener::localAddress() const {
+  return socket.localAddress();
+}
+
+const uint32_t sigSocketData = 0x39eb69f4;
+
+SharedBufferHandle toShared(SharedBufferHandle h) {
+  return h;
+}
+SharedBufferHandle toShared(BufferHandle h) {
+  return SharedBufferHandle(h.release());
+}
+
+template<typename Buffer>
+void Connection::write(Buffer buffer, Function<void(Error*)> callback) {
+  uint32_t size = buffer->size;
+  if ((size_t)size != buffer->size) {
+    throw Error("write: buffer is too large (size does not fit in 32 bits)");
+  }
+  thread_local std::vector<iovec> buffers;
+  buffers.resize(2 + buffer->nTensors);
+  buffers[1].iov_base = buffer->data();
+  buffers[1].iov_len = (std::byte*)(buffer->tensorMetaDataOffsets() + buffer->nTensors) - buffer->data();
+  auto* tensors = buffer->tensors();
+  for (size_t i = 0; i != buffer->nTensors; ++i) {
+    Tensor& tensor = tensors[i].tensor;
+    size_t length = computeStorageNbytes(tensor.sizes(), tensor.strides(), tensor.itemsize());
+    if (tensor.is_cuda()) {
+      throw Error("IPC can not send CUDA tensors");
+    } else {
+      buffers[2 + i].iov_base = tensor.data_ptr();
+      buffers[2 + i].iov_len = length;
+    }
+  }
+  auto buffer0 = serializeToBuffer(SerializeFunction([&](auto& v) {
+    v(sigSocketData, (uint32_t)buffers.size() - 1, size);
+    for (size_t i = 1; i != buffers.size(); ++i) {
+      v(buffers[i].iov_len);
+    }
+  }));
+
+  buffers[0].iov_base = buffer0->data();
+  buffers[0].iov_len = buffer0->size;
+
+  socket.writev(
+      buffers.data(), buffers.size(),
+      [buffer0 = std::move(buffer0), buffer = std::move(buffer), callback = std::move(callback)](Error* error) {
+        if (callback) {
+          callback(error);
+        }
+      });
+}
+
+template void Connection::write(BufferHandle, Function<void(Error*)>);
+template void Connection::write(SharedBufferHandle, Function<void(Error*)>);
+
+void Connection::close() {
+  socket.close();
+}
+
+void Connection::read(Function<void(Error*, BufferHandle)> callback) {
+  socket.setOnRead([this, callback = std::move(callback)](Error* error, auto* lock) mutable {
+    if (error) {
+      callback(error, nullptr);
+      return;
+    }
+
+    static constexpr int stateZero = 0;
+    static constexpr int stateSocketReadSizes = 1;
+    static constexpr int stateSocketReadIovecs = 2;
+    static constexpr int stateAllDone = 3;
+
+    while (true) {
+      switch (readState) {
+      default:
+        close();
+        return;
+      case stateZero: {
+        if (!socket.read(tmpReadBuffer.data(), 12)) {
+          return;
+        }
+        uint32_t numBuffers, bufferSize;
+        uint32_t recvSignature;
+        deserializeBuffer(tmpReadBuffer.data(), 12, recvSignature, numBuffers, bufferSize);
+        switch (recvSignature) {
+        case sigSocketData:
+          break;
+        default:
+          readState = -1;
+          Error e("bad signature");
+          callback(&e, nullptr);
+          return;
+        }
+        buffer = makeBuffer(bufferSize, numBuffers - 1);
+        bufferSizes.clear();
+        bufferSizes.resize(numBuffers);
+        readState = stateSocketReadSizes;
+        [[fallthrough]];
+      }
+      case stateSocketReadSizes: {
+        if (!socket.read(bufferSizes.data(), bufferSizes.size() * sizeof(size_t))) {
+          return;
+        }
+        if (bufferSizes[0] !=
+            size_t((std::byte*)(buffer->tensorMetaDataOffsets() + buffer->nTensors) - buffer->data())) {
+          readState = -1;
+          Error e("bad buffer size");
+          callback(&e, nullptr);
+          return;
+        }
+        allocators.clear();
+        iovecs.clear();
+        for (size_t i = 0; i != bufferSizes.size(); ++i) {
+          if (i != 0) {
+            allocators.emplace_back(rpc::kCPU, bufferSizes[i]);
+          }
+          iovec v;
+          v.iov_len = bufferSizes[i];
+          v.iov_base = i == 0 ? buffer->data() : allocators.back().data();
+          iovecs.push_back(v);
+        }
+        readState = stateSocketReadIovecs;
+        [[fallthrough]];
+      }
+      case stateSocketReadIovecs:
+        if (!socket.readv(iovecs.data(), iovecs.size())) {
+          return;
+        } else {
+          readState = stateAllDone;
+          [[fallthrough]];
+        }
+      case stateAllDone: {
+        auto* offsets = buffer->tensorMetaDataOffsets();
+        auto* tensors = buffer->tensors();
+        auto* data = buffer->data();
+        size_t nTensors = buffer->nTensors;
+        size_t len = buffer->size;
+        for (size_t i = 0; i != nTensors; ++i) {
+          Tensor& t = tensors[i].tensor;
+          decltype(t.scalar_type()) dtype;
+          decltype(t.sizes()) sizes;
+          decltype(t.strides()) strides;
+          deserializeBufferPart(data + offsets[i], len > offsets[i] ? len - offsets[i] : 0, dtype, sizes, strides);
+          t = allocators[i].set(dtype, sizes, strides);
+        }
+        readState = stateZero;
+
+        auto buf = std::move(buffer);
+        lock->unlock();
+        callbackScheduledFromBackend = true;
+        callback(nullptr, std::move(buf));
+        callbackScheduledFromBackend = false;
+        lock->lock();
+        break;
+      }
+      }
+    }
+  });
+}
+
+std::string Connection::localAddress() const {
+  return socket.localAddress();
+}
+
+std::string Connection::remoteAddress() const {
+  return socket.remoteAddress();
+}
+
+Connection::~Connection() {}
+
+std::shared_ptr<Listener> UnixContext::listen(std::string_view addr) {
+  auto listener = std::make_shared<Listener>(Socket::Unix());
+  listener->socket.listen(addr);
+  return listener;
+}
+
+std::shared_ptr<Connection> UnixContext::connect(std::string_view addr) {
+  auto connection = std::make_shared<Connection>(Socket::Unix());
+
+  connection->socket.connect(addr, [connection](Error* e) {
+    if (e) {
+      // connection->close();
+    }
+  });
+
+  return connection;
+}
+
+std::shared_ptr<Listener> TcpContext::listen(std::string_view addr) {
+  auto listener = std::make_shared<Listener>(Socket::Tcp());
+  listener->socket.listen(addr);
+  return listener;
+}
+
+std::shared_ptr<Connection> TcpContext::connect(std::string_view addr) {
+  auto connection = std::make_shared<Connection>(Socket::Tcp());
+
+  connection->socket.connect(addr, [connection](Error* e) {
+    if (e) {
+      // connection->close();
+    }
+  });
+
+  return connection;
+}
+
+} // namespace ipc
+} // namespace rpc

--- a/src/transports/ipc.cc
+++ b/src/transports/ipc.cc
@@ -189,9 +189,7 @@ void Connection::read(Function<void(Error*, BufferHandle)> callback) {
         readState = stateZero;
 
         auto buf = std::move(buffer);
-        lock->unlock();
         callback(nullptr, std::move(buf));
-        lock->lock();
         break;
       }
       }

--- a/src/transports/ipc.cc
+++ b/src/transports/ipc.cc
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "ipc.h"
 

--- a/src/transports/ipc.cc
+++ b/src/transports/ipc.cc
@@ -184,9 +184,7 @@ void Connection::read(Function<void(Error*, BufferHandle)> callback) {
 
         auto buf = std::move(buffer);
         lock->unlock();
-        callbackScheduledFromBackend = true;
         callback(nullptr, std::move(buf));
-        callbackScheduledFromBackend = false;
         lock->lock();
         break;
       }

--- a/src/transports/ipc.h
+++ b/src/transports/ipc.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/src/transports/ipc.h
+++ b/src/transports/ipc.h
@@ -45,15 +45,17 @@ struct Listener {
   std::string localAddress() const;
 };
 
+struct ConnectionImpl;
 struct Connection : std::enable_shared_from_this<Connection> {
   Socket socket;
   int readState = 0;
-  std::array<char, 32> tmpReadBuffer;
+  Function<void(Error*, BufferHandle)> readCallback;
   std::vector<size_t> bufferSizes;
   BufferHandle buffer;
-  std::vector<iovec> iovecs;
   std::vector<Allocator> allocators;
-  Connection(Socket socket) : socket(std::move(socket)) {}
+  CachedReader reader;
+
+  Connection(Socket socket) : socket(std::move(socket)), reader(this->socket) {}
   ~Connection();
 
   void close();

--- a/src/transports/ipc.h
+++ b/src/transports/ipc.h
@@ -1,0 +1,64 @@
+
+#pragma once
+
+#include "rpc.h"
+#include "socket.h"
+#include "synchronization.h"
+
+#include "fmt/printf.h"
+
+#include <memory>
+
+namespace rpc {
+
+namespace ipc {
+
+struct Connection;
+struct Listener;
+
+struct UnixContext {
+  std::shared_ptr<Listener> listen(std::string_view addr);
+  std::shared_ptr<Connection> connect(std::string_view addr);
+};
+
+struct TcpContext {
+  std::shared_ptr<Listener> listen(std::string_view addr);
+  std::shared_ptr<Connection> connect(std::string_view addr);
+};
+
+struct Listener {
+  Socket socket;
+  Listener(Socket socket) : socket(std::move(socket)) {}
+
+  void close() {
+    socket.close();
+  }
+
+  void accept(Function<void(Error*, std::shared_ptr<Connection>)> callback);
+
+  std::string localAddress() const;
+};
+
+struct Connection : std::enable_shared_from_this<Connection> {
+  Socket socket;
+  int readState = 0;
+  std::array<char, 32> tmpReadBuffer;
+  std::vector<size_t> bufferSizes;
+  BufferHandle buffer;
+  std::vector<iovec> iovecs;
+  std::vector<Allocator> allocators;
+  Connection(Socket socket) : socket(std::move(socket)) {}
+  ~Connection();
+
+  void close();
+  void read(Function<void(Error*, BufferHandle)>);
+  template<typename Buffer>
+  void write(Buffer buffer, Function<void(Error*)>);
+
+  std::string localAddress() const;
+  std::string remoteAddress() const;
+};
+
+} // namespace ipc
+
+} // namespace rpc

--- a/src/transports/socket.cc
+++ b/src/transports/socket.cc
@@ -1,0 +1,1094 @@
+
+#include "socket.h"
+
+#include "rpc.h"
+
+#include "fmt/printf.h"
+
+#include <limits.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <signal.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+namespace rpc {
+
+namespace poll {
+void add(std::shared_ptr<SocketImpl> impl);
+}
+
+struct ResolveHandle {
+  gaicb req;
+  sigevent sevp;
+  std::string address;
+  std::string service;
+  Function<void(Error*, addrinfo*)> callback;
+
+  ResolveHandle() = default;
+  ResolveHandle(const ResolveHandle&) = delete;
+  ResolveHandle& operator=(const ResolveHandle&) = delete;
+  ~ResolveHandle() {
+    gai_cancel(&req);
+  }
+};
+
+template<typename F>
+std::shared_ptr<ResolveHandle> resolveIpAddress(std::string_view address, int port, bool asynchronous, F&& callback) {
+  auto h = std::make_shared<ResolveHandle>();
+  h->address = address;
+  h->service = std::to_string(port);
+  h->req.ar_name = h->address.c_str();
+  h->req.ar_service = h->service.c_str();
+  h->req.ar_request = nullptr;
+
+  h->callback = std::move(callback);
+
+  Function<void()> f = [asynchronous, wh = std::weak_ptr<ResolveHandle>(h)]() {
+    auto h = wh.lock();
+    if (h) {
+      int e = gai_error(&h->req);
+      if (e == 0) {
+        h->callback(nullptr, h->req.ar_result);
+      } else {
+        if (!asynchronous && e == EAI_ADDRFAMILY) {
+          throw std::system_error(EAFNOSUPPORT, std::generic_category());
+        }
+        std::string str = e == EAI_SYSTEM ? std::strerror(errno) : gai_strerror(e);
+        Error e(std::move(str));
+        h->callback(&e, nullptr);
+      }
+    }
+  };
+
+  memset(&h->sevp, 0, sizeof(h->sevp));
+  h->sevp.sigev_notify = asynchronous ? SIGEV_THREAD : SIGEV_NONE;
+  h->sevp.sigev_value.sival_ptr = f.release();
+  h->sevp.sigev_notify_function = [](sigval v) { Function<void()>((FunctionPointer)v.sival_ptr)(); };
+  gaicb* ptr = &h->req;
+  int r;
+  do {
+    r = getaddrinfo_a(asynchronous ? GAI_NOWAIT : GAI_WAIT, &ptr, 1, &h->sevp);
+  } while (r == EAI_INTR);
+  if (r) {
+    Function<void()>{(FunctionPointer)h->sevp.sigev_value.sival_ptr};
+    std::string str = r == EAI_SYSTEM ? std::strerror(errno) : gai_strerror(r);
+    Error e(std::move(str));
+    if (asynchronous) {
+      scheduler.run([e = std::move(e), h]() mutable { h->callback(&e, nullptr); });
+    } else {
+      h->callback(&e, nullptr);
+    }
+    return nullptr;
+  }
+  if (!asynchronous) {
+    Function<void()>{(FunctionPointer)h->sevp.sigev_value.sival_ptr}();
+  }
+  return h;
+}
+
+static std::pair<std::string_view, int> decodeIpAddress(std::string_view address) {
+  std::string_view hostname = address;
+  int port = 0;
+  auto bpos = address.find('[');
+  if (bpos != std::string_view::npos) {
+    auto bepos = address.find(']', bpos);
+    if (bepos != std::string_view::npos) {
+      hostname = address.substr(bpos + 1, bepos - (bpos + 1));
+      address = address.substr(bepos + 1);
+    }
+  }
+  auto cpos = address.find(':');
+  if (cpos != std::string_view::npos) {
+    if (hostname == address) {
+      hostname = address.substr(0, cpos);
+    }
+    ++cpos;
+    while (cpos != address.size()) {
+      char c = address[cpos];
+      if (c < '0' || c > '9') {
+        break;
+      }
+      port *= 10;
+      port += c - '0';
+      ++cpos;
+    }
+  }
+  return {hostname, port};
+}
+
+uint32_t writeFdFlag = 0x413ffc3f;
+
+thread_local SocketImpl* inReadLoop = nullptr;
+
+struct SocketImpl : std::enable_shared_from_this<SocketImpl> {
+  int af = -1;
+  int fd = -1;
+  std::atomic_bool closed = false;
+  std::shared_ptr<ResolveHandle> resolveHandle;
+  bool addedInPoll = false;
+
+  alignas(64) std::atomic_int writeTriggerCount = 0;
+  SpinMutex writeQueueMutex;
+  std::vector<iovec> queuedWrites;
+  std::vector<std::pair<size_t, Function<void(Error*)>>> queuedWriteCallbacks;
+  SpinMutex writeMutex;
+  std::vector<iovec> newWrites;
+  std::vector<std::pair<size_t, Function<void(Error*)>>> newWriteCallbacks;
+  std::vector<iovec> activeWrites;
+  std::vector<std::pair<size_t, Function<void(Error*)>>> activeWriteCallbacks;
+
+  alignas(64) std::atomic_int readTriggerCount = 0;
+  bool wantsRead = false;
+  SpinMutex readMutex;
+  Function<void(Error*, std::unique_lock<SpinMutex>*)> onRead;
+  std::vector<char> readBuffer;
+  size_t readBufferOffset = 0;
+  size_t readBufferFilled = 0;
+  const void* prevReadPtr = nullptr;
+  size_t prevReadOffset = 0;
+  std::vector<int> receivedFds;
+
+  void close() {
+    if (closed.exchange(true)) {
+      return;
+    }
+
+    std::unique_lock l(readMutex, std::defer_lock);
+    if (inReadLoop != this) {
+      l.lock();
+    }
+    onRead = nullptr;
+    std::lock_guard l2(writeMutex);
+    std::unique_lock l3(writeQueueMutex);
+    queuedWrites.clear();
+    queuedWriteCallbacks.clear();
+    if (resolveHandle) {
+      resolveHandle = nullptr;
+    }
+    if (fd != -1) {
+      ::close(fd);
+      fd = -1;
+    }
+    for (auto v : receivedFds) {
+      ::close(v);
+    }
+  }
+
+  ~SocketImpl() {
+    close();
+  }
+
+  void listen(std::string_view address) {
+    std::unique_lock l(writeMutex);
+    if (closed.load(std::memory_order_relaxed)) {
+      return;
+    }
+    if (af == AF_UNIX) {
+      sockaddr_un sa;
+      memset(&sa, 0, sizeof(sa));
+      sa.sun_family = AF_UNIX;
+      sa.sun_path[0] = 0;
+      std::string path = "moolib-" + std::string(address);
+      size_t len = std::min(path.size(), sizeof(sa.sun_path) - 2);
+      std::memcpy(&sa.sun_path[1], path.data(), len);
+      if (::bind(fd, (const sockaddr*)&sa, sizeof(sa)) == -1) {
+        throw std::system_error(errno, std::generic_category());
+      }
+      if (::listen(fd, 50) == -1) {
+        throw std::system_error(errno, std::generic_category());
+      }
+    } else if (af == AF_INET) {
+      l.unlock();
+      int port = 0;
+      std::tie(address, port) = decodeIpAddress(address);
+      auto h =
+          resolveIpAddress(address, port, false, [this, address = std::string(address), port](Error* e, addrinfo* aix) {
+            if (e) {
+              throw *e;
+            } else {
+              std::string errors;
+              int tries = 0;
+              for (auto* i = aix; i; i = i->ai_next) {
+                if ((i->ai_family == AF_INET || i->ai_family == AF_INET6) && i->ai_socktype == SOCK_STREAM) {
+                  ++tries;
+
+                  if (fd == -1) {
+                    fd = ::socket(i->ai_family, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+                    if (fd == -1) {
+                      errors += fmt::sprintf("socket: %s", std::strerror(errno));
+                      continue;
+                    }
+                  }
+
+                  int reuseaddr = 1;
+                  ::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuseaddr, sizeof(reuseaddr));
+                  int reuseport = 1;
+                  ::setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &reuseport, sizeof(reuseport));
+
+                  if (::bind(fd, i->ai_addr, i->ai_addrlen) == 0 && ::listen(fd, 50) == 0) {
+                    poll::add(shared_from_this());
+                    return;
+                  } else {
+                    const char* se = std::strerror(errno);
+                    ::close(fd);
+                    fd = -1;
+
+                    if (!errors.empty()) {
+                      errors += ", ";
+                    }
+                    char buf[128];
+                    memset(buf, 0, sizeof(buf));
+                    int r = getnameinfo(i->ai_addr, i->ai_addrlen, buf, sizeof(buf) - 1, nullptr, 0, NI_NUMERICHOST);
+                    const char* s = r ? gai_strerror(r) : buf;
+                    errors += fmt::sprintf("%s (port %d): %s", s, port, se);
+                  }
+                }
+              }
+              if (tries == 0) {
+                errors += "Name did not resolve to any usable addresses";
+              }
+              throw Error(std::move(errors));
+            }
+          });
+      l.lock();
+      resolveHandle = std::move(h);
+    } else {
+      throw Error("listen: unkown address family\n");
+    }
+  }
+
+  void setTcpSockOpts() {
+    int nodelay = 1;
+    ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
+  }
+
+  void accept(Function<void(Error*, Socket)> callback) {
+    std::lock_guard l(readMutex);
+    if (closed.load(std::memory_order_relaxed)) {
+      return;
+    }
+    onRead = [this, callback = std::move(callback)](Error* error, auto* lock) mutable {
+      while (true) {
+        if (closed.load(std::memory_order_relaxed)) {
+          wantsRead = false;
+          return;
+        }
+        readTriggerCount.store(-0xffff, std::memory_order_relaxed);
+        int r = ::accept4(fd, nullptr, 0, SOCK_NONBLOCK | SOCK_CLOEXEC);
+        if (r == -1) {
+          wantsRead = false;
+          if (errno == EAGAIN) {
+            return;
+          }
+          return;
+        } else {
+          Socket s;
+          s.impl = std::make_shared<SocketImpl>();
+          s.impl->af = af;
+          s.impl->fd = r;
+          s.impl->setTcpSockOpts();
+          poll::add(s.impl);
+          callback(nullptr, std::move(s));
+          triggerRead();
+        }
+      }
+    };
+  }
+
+  void connect(std::string_view address, Function<void(Error*)> callback) {
+    std::unique_lock wl(writeMutex);
+    if (closed.load(std::memory_order_relaxed)) {
+      return;
+    }
+    if (af == AF_UNIX) {
+      sockaddr_un sa;
+      memset(&sa, 0, sizeof(sa));
+      sa.sun_family = AF_UNIX;
+      sa.sun_path[0] = 0;
+      std::string path = "moolib-" + std::string(address);
+      size_t len = std::min(path.size(), sizeof(sa.sun_path) - 2);
+      std::memcpy(&sa.sun_path[1], path.data(), len);
+      if (::connect(fd, (const sockaddr*)&sa, sizeof(sa)) && errno != EAGAIN) {
+        Error e(std::strerror(errno));
+        std::move(callback)(&e);
+      } else {
+        std::move(callback)(nullptr);
+        std::unique_lock ql(writeQueueMutex);
+        writeLoop(wl, ql);
+      }
+    } else {
+      wl.unlock();
+      int port = 0;
+      std::tie(address, port) = decodeIpAddress(address);
+      auto h = resolveIpAddress(
+          address, port, true,
+          [this, me = shared_from_this(), address = std::string(address)](Error* e, addrinfo* aix) {
+            std::unique_lock wl(writeMutex);
+            std::unique_lock rl(readMutex);
+            if (closed.load(std::memory_order_relaxed)) {
+              return;
+            }
+            if (!e) {
+              for (auto* i = aix; i; i = i->ai_next) {
+                if ((i->ai_family == AF_INET || i->ai_family == AF_INET6) && i->ai_socktype == SOCK_STREAM) {
+                  if (fd == -1) {
+                    fd = ::socket(i->ai_family, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+                    if (fd == -1) {
+                      continue;
+                    }
+                  }
+
+                  if (::connect(fd, i->ai_addr, i->ai_addrlen) == 0 || errno == EAGAIN || errno == EINPROGRESS) {
+                    rl.unlock();
+                    setTcpSockOpts();
+                    poll::add(shared_from_this());
+                    std::unique_lock ql(writeQueueMutex);
+                    writeLoop(wl, ql);
+                    return;
+                  } else {
+                    ::close(fd);
+                    fd = -1;
+                  }
+                }
+              }
+            }
+          });
+      wl.lock();
+      resolveHandle = std::move(h);
+    }
+  }
+
+  void triggerRead() {
+    scheduler.run([me = shared_from_this(), this] {
+      std::unique_lock l(readMutex);
+      inReadLoop = this;
+      while (true) {
+        readTriggerCount.store(-0xffff, std::memory_order_relaxed);
+        wantsRead = true;
+        while (onRead && wantsRead) {
+          onRead(nullptr, &l);
+          if (!l.owns_lock()) {
+            l.lock();
+          }
+        }
+        int v = -0xffff;
+        if (readTriggerCount.compare_exchange_strong(v, 0)) {
+          break;
+        }
+      }
+      inReadLoop = nullptr;
+    });
+  }
+
+  void triggerWrite() {
+    scheduler.run([me = shared_from_this(), this] {
+      std::unique_lock wl(writeMutex, std::try_to_lock);
+      if (wl.owns_lock()) {
+        std::unique_lock ql(writeQueueMutex);
+        writeLoop(wl, ql);
+      }
+    });
+  }
+
+  void writeLoop(std::unique_lock<SpinMutex>& wl, std::unique_lock<SpinMutex>& ql) {
+    while (true) {
+      writeTriggerCount.store(-0xffff, std::memory_order_relaxed);
+      if (queuedWrites.empty()) {
+        wl.unlock();
+        ql.unlock();
+        return;
+      }
+      activeWrites.clear();
+      activeWriteCallbacks.clear();
+      std::swap(activeWrites, queuedWrites);
+      std::swap(activeWriteCallbacks, queuedWriteCallbacks);
+      ql.unlock();
+      bool canWrite = writevImpl(
+          activeWrites.data(), activeWrites.size(), activeWriteCallbacks.data(), activeWriteCallbacks.size(), ql);
+      if (!ql.owns_lock()) {
+        ql.lock();
+      }
+      if (queuedWrites.empty()) {
+        wl.unlock();
+        ql.unlock();
+        return;
+      }
+      if (!canWrite) {
+        wl.unlock();
+        int v = -0xffff;
+        if (writeTriggerCount.compare_exchange_strong(v, 0)) {
+          ql.unlock();
+          return;
+        }
+        wl.try_lock();
+        if (!wl.owns_lock()) {
+          ql.unlock();
+          return;
+        }
+      }
+    }
+  }
+
+  void setOnRead(Function<void(Error*, std::unique_lock<SpinMutex>* lock)> callback) {
+    std::lock_guard l(readMutex);
+    if (closed.load(std::memory_order_relaxed)) {
+      return;
+    }
+    if (onRead) {
+      throw Error("onRead callback is already set");
+    }
+    onRead = std::move(callback);
+    if (readTriggerCount.load(std::memory_order_relaxed)) {
+      triggerRead();
+    }
+  }
+
+  bool read(void* dst, size_t size) {
+    if (closed.load(std::memory_order_relaxed)) {
+      wantsRead = false;
+      return false;
+    }
+    if (readBuffer.empty()) {
+      readBuffer.resize(4096);
+    }
+    if (prevReadPtr != dst) {
+      prevReadPtr = dst;
+      prevReadOffset = 0;
+      if (readBufferFilled - readBufferOffset > 0) {
+        size_t n = std::min(size, readBufferFilled - readBufferOffset);
+        std::memcpy(dst, readBuffer.data() + readBufferOffset, n);
+        readBufferOffset += n;
+        if (readBufferOffset == readBufferFilled) {
+          readBufferOffset = 0;
+          readBufferFilled = 0;
+        }
+        if (n >= size) {
+          prevReadPtr = nullptr;
+          return true;
+        }
+        prevReadOffset = n;
+      }
+      readBufferOffset = 0;
+      readBufferFilled = 0;
+    }
+    std::array<iovec, 2> readIovecs;
+    readIovecs[0].iov_base = (char*)dst + prevReadOffset;
+    readIovecs[0].iov_len = size - prevReadOffset;
+    readIovecs[1].iov_base = readBuffer.data() + readBufferOffset;
+    readIovecs[1].iov_len = readBuffer.size() - readBufferFilled;
+    if (readIovecs[0].iov_len == 0 || readIovecs[0].iov_len > size || readIovecs[1].iov_len == 0 ||
+        readIovecs[1].iov_len > readBuffer.size()) {
+      throw std::runtime_error("read bad iovec");
+    }
+    msghdr msg = {0};
+    union {
+      char buf[CMSG_SPACE(sizeof(int))];
+      cmsghdr align;
+    } u;
+    msg.msg_iov = (::iovec*)readIovecs.data();
+    msg.msg_iovlen = readIovecs.size();
+    msg.msg_control = u.buf;
+    msg.msg_controllen = sizeof(u.buf);
+    readTriggerCount.store(-0xffff, std::memory_order_relaxed);
+    ssize_t r = ::recvmsg(fd, &msg, MSG_CMSG_CLOEXEC);
+    wantsRead = r == readIovecs[0].iov_len + readIovecs[1].iov_len;
+    if (r == -1) {
+      if (errno == EINTR) {
+        wantsRead = true;
+        return false;
+      }
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        return false;
+      }
+      Error e(std::strerror(errno));
+      if (onRead) {
+        onRead(&e, nullptr);
+      }
+      return false;
+    } else {
+      if (r == 0) {
+        Error e("Connection closed");
+        if (onRead) {
+          onRead(&e, nullptr);
+        }
+        return false;
+      }
+      if (msg.msg_controllen != 0) {
+        cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
+        if (cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
+          int fd;
+          std::memcpy(&fd, CMSG_DATA(cmsg), sizeof(fd));
+          receivedFds.push_back(fd);
+        }
+      }
+      size_t dstlen = size - prevReadOffset;
+      prevReadOffset += std::min(dstlen, (size_t)r);
+      if (r > dstlen) {
+        readBufferFilled += r - dstlen;
+      }
+      if (prevReadOffset == size) {
+        prevReadPtr = nullptr;
+        return true;
+      }
+      return false;
+    }
+  }
+
+  bool readv(const iovec* vec, size_t veclen) {
+    if (closed.load(std::memory_order_relaxed)) {
+      wantsRead = false;
+      return false;
+    }
+    size_t skip = readBufferFilled - readBufferOffset;
+    const iovec* ovec = vec;
+    size_t oveclen = veclen;
+    iovec iovecbackup;
+    bool restoreIovecBackup = false;
+    if (prevReadPtr != vec) {
+      prevReadPtr = vec;
+      prevReadOffset = 0;
+    }
+    if (skip) {
+      size_t left = skip;
+      for (size_t i = 0;; ++i) {
+        if (i == veclen) {
+          if (readBufferOffset == readBufferFilled) {
+            readBufferOffset = 0;
+            readBufferFilled = 0;
+          }
+          prevReadPtr = nullptr;
+          return true;
+        }
+        if (left == 0) {
+          break;
+        }
+        size_t n = std::min(left, vec[i].iov_len);
+        std::memcpy(vec[i].iov_base, readBuffer.data() + readBufferOffset, n);
+        readBufferOffset += n;
+        left -= n;
+        prevReadOffset += n;
+        if (n < vec[i].iov_len) {
+          break;
+        }
+      }
+      if (readBufferOffset == readBufferFilled) {
+        readBufferOffset = 0;
+        readBufferFilled = 0;
+      }
+    }
+
+    size_t left = prevReadOffset;
+    for (size_t i = 0;; ++i) {
+      if (i == veclen) {
+        throw std::runtime_error("readv skipped entire buffer");
+      }
+      if (left < vec[i].iov_len) {
+        vec = &vec[i];
+        veclen -= i;
+        iovecbackup = *vec;
+        restoreIovecBackup = true;
+        iovec* v = (iovec*)vec;
+        v[0].iov_base = (char*)v[0].iov_base + left;
+        v[0].iov_len -= left;
+        break;
+      } else {
+        left -= vec[i].iov_len;
+      }
+    }
+
+    ssize_t bytes = 0;
+    for (size_t i = 0; i != veclen; ++i) {
+      bytes += vec[i].iov_len;
+    }
+
+    readTriggerCount.store(-0xffff, std::memory_order_relaxed);
+    ssize_t r = ::readv(fd, (::iovec*)vec, veclen);
+    if (restoreIovecBackup) {
+      *(iovec*)vec = iovecbackup;
+      vec = ovec;
+      veclen = oveclen;
+    }
+    wantsRead = r == bytes;
+    if (r == -1) {
+      if (errno == EINTR) {
+        wantsRead = true;
+        return false;
+      }
+      if (errno == EAGAIN || errno == EWOULDBLOCK) {
+        return false;
+      }
+      Error e(std::strerror(errno));
+      if (onRead) {
+        onRead(&e, nullptr);
+      }
+      return false;
+    } else {
+      if (r == 0) {
+        Error e("Connection closed");
+        if (onRead) {
+          onRead(&e, nullptr);
+        }
+        return false;
+      }
+      if (r < bytes) {
+        prevReadOffset += r;
+        return false;
+      } else {
+        prevReadPtr = nullptr;
+        return true;
+      }
+    }
+  }
+
+  bool writevImpl(
+      const iovec* vec, size_t veclen, std::pair<size_t, Function<void(Error*)>>* callbacks, size_t callbacksLen,
+      std::unique_lock<SpinMutex>& ql) {
+    if (closed.load(std::memory_order_relaxed)) {
+      return false;
+    }
+
+    msghdr msg;
+    union {
+      char buf[CMSG_SPACE(sizeof(int))];
+      cmsghdr align;
+    } u;
+
+    msg.msg_name = nullptr;
+    msg.msg_namelen = 0;
+    msg.msg_control = nullptr;
+    msg.msg_controllen = 0;
+    msg.msg_flags = 0;
+
+    msg.msg_iov = (::iovec*)vec;
+    msg.msg_iovlen = std::min(veclen, (size_t)IOV_MAX);
+    if (af == AF_UNIX) {
+      for (size_t i = 0; i != msg.msg_iovlen; ++i) {
+        if (vec[i].iov_base == (void*)&writeFdFlag) {
+          if (i == 0) {
+            int fd = (int)(uintptr_t)vec[i + 1].iov_base;
+            msg.msg_iovlen = 1;
+            msg.msg_control = u.buf;
+            msg.msg_controllen = sizeof(u.buf);
+            cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
+            cmsg->cmsg_level = SOL_SOCKET;
+            cmsg->cmsg_type = SCM_RIGHTS;
+            cmsg->cmsg_len = CMSG_LEN(sizeof(fd));
+            std::memcpy(CMSG_DATA(cmsg), &fd, sizeof(fd));
+            break;
+          } else {
+            msg.msg_iovlen = i;
+            break;
+          }
+        }
+      }
+    }
+    writeTriggerCount.store(-0xffff, std::memory_order_relaxed);
+    ssize_t r = ::sendmsg(fd, &msg, MSG_NOSIGNAL);
+    bool canWrite = false;
+    if (r == -1) {
+      int e = errno;
+      if (e == EAGAIN || e == EWOULDBLOCK) {
+        r = 0;
+      }
+    }
+    if (r == -1) {
+      int e = errno;
+      if (e == EINTR) {
+        canWrite = true;
+      }
+      Error ee(std::strerror(e));
+      std::move(callbacks[0].second)(&ee);
+      activeWrites.clear();
+      activeWriteCallbacks.clear();
+      ql.lock();
+      queuedWrites.clear();
+      queuedWriteCallbacks.clear();
+    } else {
+      size_t writtenForCallback = 0;
+      while (writtenForCallback) {
+        if (callbacksLen == 0) {
+          throw Error("writev empty callback list");
+        }
+        if (writtenForCallback >= callbacks[0].first) {
+          // Function<void(Error*)>>{std::move(callbacks[0].second)};
+          writtenForCallback -= callbacks[0].first;
+          ++callbacks;
+          --callbacksLen;
+        } else {
+          break;
+        }
+      }
+      size_t offset = 0;
+      for (; offset != veclen; ++offset) {
+        if (r < vec[offset].iov_len) {
+          break;
+        }
+        r -= vec[offset].iov_len;
+      }
+      if (offset == veclen) {
+        canWrite = true;
+        activeWrites.clear();
+        activeWriteCallbacks.clear();
+      } else {
+        newWrites.clear();
+        newWriteCallbacks.clear();
+        for (size_t i = offset; i != veclen; ++i) {
+          if (i == offset) {
+            iovec v;
+            v.iov_base = (char*)vec[i].iov_base + r;
+            v.iov_len = vec[i].iov_len - r;
+            newWrites.push_back(v);
+          } else {
+            newWrites.push_back(vec[i]);
+          }
+        }
+        for (size_t i = 0; i != callbacksLen; ++i) {
+          if (i == 0) {
+            newWriteCallbacks.emplace_back(callbacks[i].first - writtenForCallback, std::move(callbacks[i].second));
+          } else {
+            newWriteCallbacks.push_back(std::move(callbacks[i]));
+          }
+        }
+        activeWrites.clear();
+        activeWriteCallbacks.clear();
+        ql.lock();
+        if (!queuedWrites.empty()) {
+          for (auto& v : queuedWrites) {
+            newWrites.push_back(v);
+          }
+          for (auto& v : queuedWriteCallbacks) {
+            newWriteCallbacks.push_back(std::move(v));
+          }
+          queuedWrites.clear();
+          queuedWriteCallbacks.clear();
+        }
+        std::swap(queuedWrites, newWrites);
+        std::swap(queuedWriteCallbacks, newWriteCallbacks);
+      }
+    }
+
+    return canWrite;
+  }
+
+  void writev(const iovec* vec, size_t veclen, Function<void(Error*)> callback) {
+    std::unique_lock ql(writeQueueMutex);
+    if (closed.load(std::memory_order_relaxed)) {
+      return;
+    }
+    std::unique_lock wl(writeMutex, std::defer_lock);
+    if (queuedWrites.empty()) {
+      if (wl.try_lock() && fd != -1) {
+        ql.unlock();
+        size_t bytes = 0;
+        for (size_t i = 0; i != veclen; ++i) {
+          bytes += vec[i].iov_len;
+        }
+        std::pair<size_t, Function<void(Error*)>> p;
+        p.first = bytes;
+        p.second = std::move(callback);
+        bool canWrite = writevImpl(vec, veclen, &p, 1, ql);
+        if (!ql.owns_lock()) {
+          ql.lock();
+        }
+        if (queuedWrites.empty()) {
+          wl.unlock();
+          ql.unlock();
+          return;
+        }
+        if (!canWrite) {
+          wl.unlock();
+          int v = -0xffff;
+          if (writeTriggerCount.compare_exchange_strong(v, 0)) {
+            ql.unlock();
+            return;
+          }
+          wl.try_lock();
+          if (!wl.owns_lock()) {
+            ql.unlock();
+            return;
+          }
+        }
+        writeLoop(wl, ql);
+        return;
+      } else if (wl.owns_lock()) {
+        wl.unlock();
+      }
+    }
+    size_t bytes = 0;
+    for (size_t i = 0; i != veclen; ++i) {
+      queuedWrites.push_back(vec[i]);
+      bytes += vec[i].iov_len;
+    }
+    queuedWriteCallbacks.emplace_back(bytes, std::move(callback));
+  }
+
+  void sendFd(int fd, Function<void(Error*)> callback) {
+    std::array<iovec, 2> iovecs;
+    iovecs[0].iov_base = &writeFdFlag;
+    iovecs[0].iov_len = 4;
+    iovecs[1].iov_base = (void*)(uintptr_t)fd;
+    iovecs[1].iov_len = 0;
+    writev(iovecs.data(), 2, std::move(callback));
+  }
+
+  int recvFd() {
+    uint32_t flag = 0;
+    if (!read(&flag, sizeof(flag))) {
+      return -1;
+    }
+    if (flag != writeFdFlag) {
+      Error e("recvFd flag mismatch");
+      if (onRead) {
+        onRead(&e, nullptr);
+      }
+      return -1;
+    }
+    if (receivedFds.empty()) {
+      Error e("receivedFds is empty!");
+      if (onRead) {
+        onRead(&e, nullptr);
+      }
+      return -1;
+    }
+    int fd = receivedFds.front();
+    receivedFds.erase(receivedFds.begin());
+    return fd;
+  }
+
+  static std::string ipAndPort(const sockaddr* addr, socklen_t addrlen) {
+    char host[128];
+    memset(host, 0, sizeof(host));
+    char port[16];
+    memset(port, 0, sizeof(port));
+    int r = getnameinfo(addr, addrlen, host, sizeof(host) - 1, port, sizeof(port) - 1, NI_NUMERICHOST | NI_NUMERICSERV);
+    if (r) {
+      throw std::runtime_error(gai_strerror(r));
+    }
+    if (addr->sa_family == AF_INET) {
+      return fmt::sprintf("%s:%s", host, port);
+    } else if (addr->sa_family == AF_INET6) {
+      return fmt::sprintf("[%s]:%s", host, port);
+    } else {
+      return "";
+    }
+  }
+
+  std::string localAddress() const {
+    if (af == AF_INET) {
+      sockaddr_storage addr;
+      socklen_t addrlen = sizeof(addr);
+      if (::getsockname(fd, (sockaddr*)&addr, &addrlen)) {
+        throw std::system_error(errno, std::generic_category());
+      }
+      return ipAndPort((const sockaddr*)&addr, addrlen);
+    } else {
+      return "";
+    }
+  }
+
+  std::string remoteAddress() const {
+    if (af == AF_INET) {
+      sockaddr_storage addr;
+      socklen_t addrlen = sizeof(addr);
+      if (::getpeername(fd, (sockaddr*)&addr, &addrlen)) {
+        throw std::system_error(errno, std::generic_category());
+      }
+      return ipAndPort((const sockaddr*)&addr, addrlen);
+    } else {
+      return "";
+    }
+  }
+};
+
+namespace poll {
+
+struct PollThread {
+  ~PollThread() {
+    terminate = true;
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+  bool terminate = false;
+  std::once_flag flag;
+  std::thread thread;
+  int fd = -1;
+  std::atomic_bool anyDead = false;
+  std::mutex mutex;
+  std::vector<std::shared_ptr<SocketImpl>> activeList;
+  std::vector<std::shared_ptr<SocketImpl>> deadList;
+
+  void entry() {
+    std::array<epoll_event, 1024> events;
+
+    while (!terminate) {
+      int n = epoll_wait(fd, events.data(), events.size(), 250);
+      if (n < 0) {
+        if (errno == EINTR) {
+          continue;
+        }
+        throw std::system_error(errno, std::generic_category());
+      }
+      for (int i = 0; i != n; ++i) {
+        if (events[i].events & (EPOLLIN | EPOLLERR)) {
+          SocketImpl* impl = (SocketImpl*)events[i].data.ptr;
+          if (++impl->readTriggerCount == 1) {
+            impl->triggerRead();
+          }
+        }
+        if (events[i].events & EPOLLOUT) {
+          SocketImpl* impl = (SocketImpl*)events[i].data.ptr;
+          if (++impl->writeTriggerCount == 1) {
+            impl->triggerWrite();
+          }
+        }
+      }
+
+      if (n < events.size() && anyDead.load(std::memory_order_relaxed)) {
+        anyDead = false;
+        std::lock_guard l(mutex);
+        deadList.clear();
+      }
+    }
+
+    close(fd);
+  }
+
+  void add(std::shared_ptr<SocketImpl> impl) {
+    std::lock_guard l(mutex);
+    std::call_once(flag, [&] {
+      fd = epoll_create1(EPOLL_CLOEXEC);
+      if (fd == -1) {
+        throw std::system_error(errno, std::generic_category());
+      }
+      thread = std::thread([&] { entry(); });
+    });
+    epoll_event e;
+    e.data.ptr = &*impl;
+    e.events = EPOLLIN | EPOLLOUT | EPOLLET;
+    if (epoll_ctl(fd, EPOLL_CTL_ADD, impl->fd, &e)) {
+      throw std::system_error(errno, std::generic_category());
+    }
+    impl->addedInPoll = true;
+    activeList.push_back(std::move(impl));
+  }
+  void remove(SocketImpl* impl) {
+    std::lock_guard l(mutex);
+    impl->addedInPoll = false;
+    epoll_event e;
+    epoll_ctl(fd, EPOLL_CTL_DEL, impl->fd, &e);
+
+    for (auto i = activeList.begin(); i != activeList.end(); ++i) {
+      if (impl == &**i) {
+        anyDead = true;
+        deadList.push_back(std::move(*i));
+        activeList.erase(i);
+        break;
+      }
+    }
+  }
+};
+PollThread pollThread;
+
+void add(std::shared_ptr<SocketImpl> impl) {
+  pollThread.add(impl);
+}
+
+void remove(SocketImpl* impl) {
+  pollThread.remove(impl);
+}
+
+} // namespace poll
+
+Socket Socket::Unix() {
+  Socket r;
+  r.impl = std::make_shared<SocketImpl>();
+  r.impl->af = AF_UNIX;
+  r.impl->fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+  if (r.impl->fd == -1) {
+    throw std::system_error(errno, std::generic_category());
+  }
+  poll::add(r.impl);
+  return r;
+}
+
+Socket Socket::Tcp() {
+  Socket r;
+  r.impl = std::make_shared<SocketImpl>();
+  r.impl->af = AF_INET;
+  r.impl->fd = -1;
+  return r;
+}
+
+Socket::Socket() {}
+Socket::Socket(Socket&& n) {
+  std::swap(impl, n.impl);
+}
+Socket& Socket::operator=(Socket&& n) {
+  std::swap(impl, n.impl);
+  return *this;
+}
+
+Socket::~Socket() {
+  close();
+}
+
+void Socket::close() {
+  if (impl) {
+    if (impl->addedInPoll) {
+      poll::remove(&*impl);
+    }
+    impl->close();
+  }
+}
+
+void Socket::writev(const iovec* vec, size_t veclen, Function<void(Error*)> callback) {
+  impl->writev(vec, veclen, std::move(callback));
+}
+
+void Socket::listen(std::string_view address) {
+  impl->listen(address);
+}
+
+void Socket::accept(Function<void(Error*, Socket)> callback) {
+  impl->accept(std::move(callback));
+}
+
+void Socket::connect(std::string_view address, Function<void(Error*)> callback) {
+  impl->connect(address, std::move(callback));
+}
+
+void Socket::setOnRead(Function<void(Error*, std::unique_lock<SpinMutex>*)> callback) {
+  impl->setOnRead(std::move(callback));
+}
+
+bool Socket::read(void* dst, size_t size) {
+  return impl->read(dst, size);
+}
+
+bool Socket::readv(const iovec* vec, size_t veclen) {
+  return impl->readv(vec, veclen);
+}
+
+void Socket::sendFd(int fd, Function<void(Error*)> callback) {
+  impl->sendFd(fd, std::move(callback));
+}
+
+int Socket::recvFd() {
+  return impl->recvFd();
+}
+
+std::string Socket::localAddress() const {
+  return impl->localAddress();
+}
+
+std::string Socket::remoteAddress() const {
+  return impl->remoteAddress();
+}
+
+} // namespace rpc

--- a/src/transports/socket.cc
+++ b/src/transports/socket.cc
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #include "socket.h"
 

--- a/src/transports/socket.cc
+++ b/src/transports/socket.cc
@@ -715,7 +715,6 @@ struct SocketImpl : std::enable_shared_from_this<SocketImpl> {
           throw Error("writev empty callback list");
         }
         if (writtenForCallback >= callbacks[0].first) {
-          // Function<void(Error*)>>{std::move(callbacks[0].second)};
           writtenForCallback -= callbacks[0].first;
           ++callbacks;
           --callbacksLen;

--- a/src/transports/socket.cc
+++ b/src/transports/socket.cc
@@ -306,11 +306,6 @@ struct SocketImpl : std::enable_shared_from_this<SocketImpl> {
   bool wantsRead = false;
   SpinMutex readMutex;
   Function<void(Error*, std::unique_lock<SpinMutex>*)> onRead;
-  std::vector<char> readBuffer;
-  size_t readBufferOffset = 0;
-  size_t readBufferFilled = 0;
-  const void* prevReadPtr = nullptr;
-  size_t prevReadOffset = 0;
   std::vector<int> receivedFds;
 
   void close() {
@@ -532,6 +527,7 @@ struct SocketImpl : std::enable_shared_from_this<SocketImpl> {
         readTriggerCount.store(-0xffff, std::memory_order_relaxed);
         wantsRead = true;
         while (onRead && wantsRead) {
+          wantsRead = false;
           onRead(nullptr, &l);
           if (!l.owns_lock()) {
             l.lock();
@@ -608,163 +604,11 @@ struct SocketImpl : std::enable_shared_from_this<SocketImpl> {
     triggerRead();
   }
 
-  bool read(void* dst, size_t size) {
+  size_t readv(const iovec* vec, size_t veclen) {
     if (closed.load(std::memory_order_relaxed) || fd == -1) {
       wantsRead = false;
-      return false;
+      return 0;
     }
-    if (readBuffer.empty()) {
-      readBuffer.resize(65536);
-    }
-    if (prevReadPtr != dst) {
-      prevReadPtr = dst;
-      prevReadOffset = 0;
-      if (readBufferFilled - readBufferOffset > 0) {
-        size_t n = std::min(size, readBufferFilled - readBufferOffset);
-        std::memcpy(dst, readBuffer.data() + readBufferOffset, n);
-        readBufferOffset += n;
-        if (readBufferOffset == readBufferFilled) {
-          readBufferOffset = 0;
-          readBufferFilled = 0;
-        }
-        if (n >= size) {
-          prevReadPtr = nullptr;
-          return true;
-        }
-        prevReadOffset = n;
-      }
-      readBufferOffset = 0;
-      readBufferFilled = 0;
-    }
-    std::array<iovec, 2> readIovecs;
-    readIovecs[0].iov_base = (char*)dst + prevReadOffset;
-    readIovecs[0].iov_len = size - prevReadOffset;
-    readIovecs[1].iov_base = readBuffer.data() + readBufferOffset;
-    readIovecs[1].iov_len = readBuffer.size() - readBufferFilled;
-    msghdr msg = {0};
-    union {
-      char buf[CMSG_SPACE(sizeof(int))];
-      cmsghdr align;
-    } u;
-    msg.msg_iov = (::iovec*)readIovecs.data();
-    msg.msg_iovlen = readIovecs.size();
-    msg.msg_control = u.buf;
-    msg.msg_controllen = sizeof(u.buf);
-    readTriggerCount.store(-0xffff, std::memory_order_relaxed);
-    ssize_t r = ::recvmsg(fd, &msg, MSG_CMSG_CLOEXEC);
-    wantsRead = r == readIovecs[0].iov_len + readIovecs[1].iov_len;
-    if (r == -1) {
-      int error = errno;
-      if (error == EINTR) {
-        wantsRead = true;
-        return false;
-      }
-      if (error == EAGAIN || error == EWOULDBLOCK || error == ENOTCONN) {
-        return false;
-      }
-      Error e(std::strerror(error));
-      if (onRead) {
-        onRead(&e, nullptr);
-      }
-      return false;
-    } else {
-      if (r == 0) {
-        Error e("Connection closed");
-        if (onRead) {
-          onRead(&e, nullptr);
-        }
-        return false;
-      }
-      if (msg.msg_controllen != 0) {
-        cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
-        if (cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
-          int fd;
-          std::memcpy(&fd, CMSG_DATA(cmsg), sizeof(fd));
-          receivedFds.push_back(fd);
-        }
-      }
-      size_t dstlen = size - prevReadOffset;
-      prevReadOffset += std::min(dstlen, (size_t)r);
-      if (r > dstlen) {
-        readBufferFilled += r - dstlen;
-      }
-      if (prevReadOffset == size) {
-        prevReadPtr = nullptr;
-        return true;
-      }
-      return false;
-    }
-  }
-
-  bool readv(const iovec* vec, size_t veclen) {
-    if (closed.load(std::memory_order_relaxed) || fd == -1) {
-      wantsRead = false;
-      return false;
-    }
-    size_t skip = readBufferFilled - readBufferOffset;
-    const iovec* ovec = vec;
-    size_t oveclen = veclen;
-    iovec iovecbackup;
-    bool restoreIovecBackup = false;
-    if (prevReadPtr != vec) {
-      prevReadPtr = vec;
-      prevReadOffset = 0;
-    }
-    if (skip) {
-      size_t left = skip;
-      for (size_t i = 0;; ++i) {
-        if (i == veclen) {
-          if (readBufferOffset == readBufferFilled) {
-            readBufferOffset = 0;
-            readBufferFilled = 0;
-          }
-          prevReadPtr = nullptr;
-          return true;
-        }
-        if (left == 0) {
-          break;
-        }
-        size_t n = std::min(left, vec[i].iov_len);
-        std::memcpy(vec[i].iov_base, readBuffer.data() + readBufferOffset, n);
-        readBufferOffset += n;
-        left -= n;
-        prevReadOffset += n;
-        if (n < vec[i].iov_len) {
-          break;
-        }
-      }
-      if (readBufferOffset == readBufferFilled) {
-        readBufferOffset = 0;
-        readBufferFilled = 0;
-      }
-    }
-
-    size_t left = prevReadOffset;
-    if (left) {
-      for (size_t i = 0;; ++i) {
-        if (i == veclen) {
-          throw std::runtime_error("readv skipped entire buffer");
-        }
-        if (left < vec[i].iov_len) {
-          vec = &vec[i];
-          veclen -= i;
-          iovecbackup = *vec;
-          restoreIovecBackup = true;
-          iovec* v = (iovec*)vec;
-          v[0].iov_base = (char*)v[0].iov_base + left;
-          v[0].iov_len -= left;
-          break;
-        } else {
-          left -= vec[i].iov_len;
-        }
-      }
-    }
-
-    ssize_t bytes = 0;
-    for (size_t i = 0; i != veclen; ++i) {
-      bytes += vec[i].iov_len;
-    }
-
     msghdr msg = {0};
     msg.msg_iov = (::iovec*)vec;
     msg.msg_iovlen = std::min(veclen, (size_t)IOV_MAX);
@@ -772,41 +616,30 @@ struct SocketImpl : std::enable_shared_from_this<SocketImpl> {
     msg.msg_controllen = 0;
     readTriggerCount.store(-0xffff, std::memory_order_relaxed);
     ssize_t r = ::recvmsg(fd, &msg, 0);
-    if (restoreIovecBackup) {
-      *(iovec*)vec = iovecbackup;
-      vec = ovec;
-      veclen = oveclen;
-    }
-    wantsRead = r == bytes;
+    wantsRead = true;
     if (r == -1) {
       int error = errno;
       if (error == EINTR) {
-        wantsRead = true;
-        return false;
+        return 0;
       }
+      wantsRead = false;
       if (error == EAGAIN || error == EWOULDBLOCK || error == ENOTCONN) {
-        return false;
+        return 0;
       }
-      Error e(std::strerror(errno));
+      Error e(std::strerror(error));
       if (onRead) {
         onRead(&e, nullptr);
       }
-      return false;
+      return 0;
     } else {
       if (r == 0) {
         Error e("Connection closed");
         if (onRead) {
           onRead(&e, nullptr);
         }
-        return false;
+        return 0;
       }
-      if (r < bytes) {
-        prevReadOffset += r;
-        return false;
-      } else {
-        prevReadPtr = nullptr;
-        return true;
-      }
+      return r;
     }
   }
 
@@ -1020,9 +853,9 @@ struct SocketImpl : std::enable_shared_from_this<SocketImpl> {
     writev(iovecs.data(), 2, std::move(callback));
   }
 
-  int recvFd() {
+  int recvFd(CachedReader& reader) {
     uint32_t flag = 0;
-    if (!read(&flag, sizeof(flag))) {
+    if (!reader.readCopy(&flag, sizeof(flag))) {
       return -1;
     }
     if (flag != writeFdFlag) {
@@ -1251,11 +1084,7 @@ void Socket::setOnRead(Function<void(Error*, std::unique_lock<SpinMutex>*)> call
   impl->setOnRead(std::move(callback));
 }
 
-bool Socket::read(void* dst, size_t size) {
-  return impl->read(dst, size);
-}
-
-bool Socket::readv(const iovec* vec, size_t veclen) {
+size_t Socket::readv(const iovec* vec, size_t veclen) {
   return impl->readv(vec, veclen);
 }
 
@@ -1263,8 +1092,8 @@ void Socket::sendFd(int fd, Function<void(Error*)> callback) {
   impl->sendFd(fd, std::move(callback));
 }
 
-int Socket::recvFd() {
-  return impl->recvFd();
+int Socket::recvFd(CachedReader& reader) {
+  return impl->recvFd(reader);
 }
 
 std::string Socket::localAddress() const {
@@ -1273,6 +1102,10 @@ std::string Socket::localAddress() const {
 
 std::string Socket::remoteAddress() const {
   return impl->remoteAddress();
+}
+
+int Socket::nativeFd() const {
+  return impl->fd;
 }
 
 } // namespace rpc

--- a/src/transports/socket.h
+++ b/src/transports/socket.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 #pragma once
 

--- a/src/transports/socket.h
+++ b/src/transports/socket.h
@@ -1,0 +1,50 @@
+
+#pragma once
+
+#include "rpc.h"
+
+#include <memory>
+#include <mutex>
+#include <string_view>
+
+namespace rpc {
+
+struct iovec {
+  void* iov_base = nullptr;
+  size_t iov_len = 0;
+};
+
+struct SocketImpl;
+
+struct Socket {
+  std::shared_ptr<SocketImpl> impl;
+  Socket();
+  Socket(const Socket&) = delete;
+  Socket(Socket&& n);
+  ~Socket();
+  Socket& operator=(const Socket&) = delete;
+  Socket& operator=(Socket&& n);
+  static Socket Unix();
+  static Socket Tcp();
+
+  void close();
+
+  void listen(std::string_view address);
+  void accept(Function<void(Error*, Socket)> callback);
+  void connect(std::string_view address, Function<void(Error*)> callback);
+
+  void writev(const iovec* vec, size_t veclen, Function<void(Error*)> callback);
+
+  void setOnRead(Function<void(Error*, std::unique_lock<SpinMutex>*)> callback);
+
+  bool read(void* dst, size_t size);
+  bool readv(const iovec* vec, size_t veclen);
+
+  void sendFd(int fd, Function<void(Error*)> callback);
+  int recvFd();
+
+  std::string localAddress() const;
+  std::string remoteAddress() const;
+};
+
+} // namespace rpc

--- a/src/transports/socket.h
+++ b/src/transports/socket.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <mutex>
 #include <string_view>
+#include <vector>
 
 namespace rpc {
 
@@ -20,8 +21,9 @@ struct iovec {
   size_t iov_len = 0;
 };
 
-struct SocketImpl;
+struct CachedReader;
 
+struct SocketImpl;
 struct Socket {
   std::shared_ptr<SocketImpl> impl;
   Socket();
@@ -43,14 +45,130 @@ struct Socket {
 
   void setOnRead(Function<void(Error*, std::unique_lock<SpinMutex>*)> callback);
 
-  bool read(void* dst, size_t size);
-  bool readv(const iovec* vec, size_t veclen);
+  size_t readv(const iovec* vec, size_t veclen);
 
   void sendFd(int fd, Function<void(Error*)> callback);
-  int recvFd();
+  int recvFd(CachedReader& reader);
 
   std::string localAddress() const;
   std::string remoteAddress() const;
+
+  int nativeFd() const;
+};
+
+struct CachedReader {
+  std::vector<iovec> iovecs;
+  size_t iovecsOffset;
+  Socket* socket;
+  size_t bufferFilled = 0;
+  size_t bufferOffset = 0;
+  std::vector<char> buffer;
+  CachedReader(Socket& socket) : socket(&socket) {}
+  void newRead() {
+    iovecs.clear();
+    iovecsOffset = 0;
+  }
+  void addIovec(const iovec& v) {
+    iovecs.push_back(v);
+  }
+  void addIovec(void* dst, size_t len) {
+    iovecs.push_back(iovec{dst, len});
+  }
+  void startRead() {
+    if (buffer.size() < 4096) {
+      buffer.resize(4096);
+    }
+    iovecsOffset = 0;
+    size_t skip = bufferFilled - bufferOffset;
+    if (skip) {
+      size_t left = skip;
+      size_t offset = bufferOffset;
+      char* src = buffer.data() + bufferOffset;
+      const char* end = buffer.data() + bufferFilled;
+      for (auto& v : iovecs) {
+        size_t n = std::min(left, v.iov_len);
+        std::memcpy(v.iov_base, src, n);
+        v.iov_base = (char*)v.iov_base + n;
+        v.iov_len -= n;
+        if (v.iov_len == 0) {
+          ++iovecsOffset;
+        }
+        src += n;
+        left -= n;
+        if (left == 0) {
+          break;
+        }
+      }
+      bufferOffset = src - buffer.data();
+      if (bufferOffset == bufferFilled) {
+        bufferOffset = 0;
+        bufferFilled = 0;
+      }
+    }
+    iovecs.push_back({buffer.data() + bufferFilled, buffer.size() - bufferFilled});
+  }
+  bool done() {
+    if (iovecsOffset && iovecsOffset == iovecs.size() - 1) {
+      return true;
+    }
+    size_t n = socket->readv(iovecs.data() + iovecsOffset, iovecs.size() - iovecsOffset);
+    bool retval = false;
+    size_t i = iovecsOffset;
+    size_t e = iovecs.size() - 1;
+    for (; i != e; ++i) {
+      auto& v = iovecs[i];
+      if (n >= v.iov_len) {
+        n -= v.iov_len;
+        v.iov_len = 0;
+        ++iovecsOffset;
+        if (n == 0) {
+          ++i;
+          break;
+        }
+      } else {
+        v.iov_base = (char*)v.iov_base + n;
+        v.iov_len -= n;
+        return false;
+      }
+    }
+    if (i == e) {
+      bufferFilled += n;
+      constexpr size_t maxBufferSize = 256 * 1024;
+      if (bufferFilled == buffer.size() && buffer.size() < maxBufferSize) {
+        buffer.resize(std::min(buffer.size() * 2, maxBufferSize));
+      }
+      return true;
+    }
+    return false;
+  }
+  void* readBufferPointer(size_t len) {
+    if (bufferFilled - bufferOffset >= len) {
+      size_t o = bufferOffset;
+      bufferOffset += len;
+      return buffer.data() + o;
+    }
+    if (buffer.size() < bufferOffset + len) {
+      buffer.resize(bufferOffset + len);
+    }
+    newRead();
+    startRead();
+    done();
+    if (bufferFilled - bufferOffset >= len) {
+      size_t o = bufferOffset;
+      bufferOffset += len;
+      return buffer.data() + o;
+    }
+    return nullptr;
+  }
+  bool readCopy(void* dst, size_t len) {
+    void* ptr = readBufferPointer(len);
+    if (ptr) {
+      std::memcpy(dst, ptr, len);
+      return true;
+    } else {
+      return false;
+    }
+  }
 };
 
 } // namespace rpc


### PR DESCRIPTION
This is an entirely new backend/transport for the rpc, using sockets.
ipc uses unix sockets, tcp uses regular tcp/ip sockets.
Tensorpipe is now disabled by default, and will be removed in the future.
Neither Cuda tensors nor Infiniband is supported, yet.