### PR TITLE
Hotfix for timeouts seen in rlmeta

### DIFF
--- a/src/transports/ipc.h
+++ b/src/transports/ipc.h
@@ -55,7 +55,7 @@ struct Connection : std::enable_shared_from_this<Connection> {
   std::vector<Allocator> allocators;
   CachedReader reader;
 
-  Connection(Socket socket) : socket(std::move(socket)), reader(this->socket) {}
+  Connection(Socket socket) : socket(std::move(socket)), reader(&this->socket) {}
   ~Connection();
 
   void close();


### PR DESCRIPTION
The main thing is that this disables long timeouts on connections (closes connections after 30 seconds of inactivity). I don't know why that breaks things, but it seems, on a rare occasion, it does.

I bundled in some other small fixes which may be related.
