### PR TITLE
Add missing headers to fix build on some platforms

### DIFF
--- a/src/tensor.h
+++ b/src/tensor.h
@@ -9,8 +9,11 @@
 
 #include "any.h"
 
+#include <cstddef>
 #include <optional>
 #include <string_view>
+#include <utility>
+#include <vector>
 
 namespace rpc {
 


### PR DESCRIPTION
There is a missing #include <vector> in tensor.h which leads to some build failures on some machines. This PR adds it back.