### PR TITLE
Fix an accidental float duration conversion in Future wait.

### DIFF
--- a/src/moolib.cc
+++ b/src/moolib.cc
@@ -289,7 +289,8 @@ struct FutureWrapper {
   void wait(float timeout) {
     py::gil_scoped_release gil;
     auto now = std::chrono::steady_clock::now();
-    auto end = now + std::chrono::duration<float, std::ratio<1, 1>>(timeout);
+    auto end = now + std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                         std::chrono::duration<float, std::ratio<1, 1>>(timeout));
     while (!done()) {
       if (now >= end) {
         throw TimeoutError();


### PR DESCRIPTION
This caused waits (on Futures, eg. as returned from async_) with timeouts to be broken, oh no! (timeout would be rounded down due to precision loss in accidental float conversion)