### PR TITLE
Improved peer discovery & connection logic.

### DIFF
--- a/src/transports/ipc.h
+++ b/src/transports/ipc.h
@@ -25,11 +25,15 @@ struct Listener;
 struct UnixContext {
   std::shared_ptr<Listener> listen(std::string_view addr);
   std::shared_ptr<Connection> connect(std::string_view addr);
+  static bool isReachable(std::string_view networkKey, std::string_view address);
+  static std::string getNetworkKey();
 };
 
 struct TcpContext {
   std::shared_ptr<Listener> listen(std::string_view addr);
   std::shared_ptr<Connection> connect(std::string_view addr);
+  static bool isReachable(std::string_view networkKey, std::string_view address);
+  static std::string getNetworkKey();
 };
 
 struct Listener {
@@ -42,7 +46,7 @@ struct Listener {
 
   void accept(Function<void(Error*, std::shared_ptr<Connection>)> callback);
 
-  std::string localAddress() const;
+  std::vector<std::string> localAddresses() const;
 };
 
 struct ConnectionImpl;

--- a/src/transports/socket.h
+++ b/src/transports/socket.h
@@ -19,6 +19,18 @@
 
 namespace rpc {
 
+std::pair<std::string_view, int> decodeIpAddress(std::string_view address);
+
+inline bool isLoopbackAddress(std::string_view address) {
+  std::tie(address, std::ignore) = decodeIpAddress(address);
+  return address == "::1" || address == "127.0.0.1";
+}
+
+inline bool isAnyAddress(std::string_view address) {
+  std::tie(address, std::ignore) = decodeIpAddress(address);
+  return address == "" || address == "::" || address == "0.0.0.0";
+}
+
 struct iovec {
   void* iov_base = nullptr;
   size_t iov_len = 0;
@@ -53,6 +65,7 @@ struct Socket {
   void sendFd(int fd, Function<void(Error*)> callback);
   int recvFd(CachedReader& reader);
 
+  std::vector<std::string> localAddresses() const;
   std::string localAddress() const;
   std::string remoteAddress() const;
 


### PR DESCRIPTION
We now resolve our local interface addresses (when listening on any address), to use in greetings to other peers. We also preserve all original addresses in onGreeting, in addition to the existing remote address + port fiddling. These together fixes an issue where if A and B are connected through a loopback interface, and C connects to A, then asks A for information about B, C would only receive loopback addresses, which may not be usable.

In addition, there is now some additional logic around connecting which uses boot_id (read from /proc) to determine if we should even try to connect through loopback addresses or through unix sockets. This makes establishing a working connection quicker.